### PR TITLE
Added Brazilian Portuguese translation of messages

### DIFF
--- a/i18n/messages.pt_br.js
+++ b/i18n/messages.pt_br.js
@@ -9,7 +9,7 @@ window.ParsleyConfig = window.ParsleyConfig || {};
           , url:        "Este valor deve ser uma URL válida."
           , urlstrict:  "Este valor deve ser uma URL válida."
           , number:     "Este valor deve ser um número válido."
-          , digits:     "Este valor deve ser uma URL válida."
+          , digits:     "Este valor deve ser um dígito válido."
           , dateIso:    "Este valor deve ser uma data válida (YYYY-MM-DD)."
           , alphanum:   "Este valor deve ser alfanumérico."
         }


### PR DESCRIPTION
I've added the three messages ( _minwords_, _maxwords_ and _rangewords_) from parsley.extend.js file to the translation file. Let me know if it should be in another file.
