### PR TITLE
New version for error messages in French

### DIFF
--- a/i18n/messages.fr.js
+++ b/i18n/messages.fr.js
@@ -3,7 +3,7 @@ window.ParsleyConfig = window.ParsleyConfig || {};
 (function ($) {
   window.ParsleyConfig = $.extend( true, {}, window.ParsleyConfig, {
     messages: {
-        defaultMessage: "Cette valeur semble invalide."
+        defaultMessage: "Cette valeur semble non valide."
       , type: {
             email:      "Cette valeur n'est pas une adresse email valide."
           , url:        "Cette valeur n'est pas une URL valide."
@@ -16,7 +16,7 @@ window.ParsleyConfig = window.ParsleyConfig || {};
       , notnull:        "Cette valeur ne peux pas être nulle."
       , notblank:       "Cette valeur ne peux pas être vide."
       , required:       "Ce champ est requis."
-      , regexp:         "Cette valeur semble invalide."
+      , regexp:         "Cette valeur semble non valide."
       , min:            "Cette valeur ne doit pas être inféreure à %s."
       , max:            "Cette valeur ne doit pas excéder %s."
       , range:          "Cette valeur doit être comprise entre %s et %s."


### PR DESCRIPTION
Invalide isn't the good way of saying that a field's value isn't correct. Invalide is used when you want to talk for example, about someone is cannot do a certain thing because of an injury.
