### PR TITLE
Update version to 1.1.5 in component.json

### DIFF
--- a/component.json
+++ b/component.json
@@ -1,6 +1,6 @@
 {
   "name": "parsleyjs",
-  "version": "1.1.3",
+  "version": "1.1.5",
   "main": ["./dist/*", "./i18n/*"],
   "dependencies": {
     "jquery": "1.8.*"


### PR DESCRIPTION
bower is saying "The version specified in the component.json of package parsleyjs mismatches the tag (1.1.5 vs 1.1.3)"
