### PR TITLE
focus: "none" raises an error

### DIFF
--- a/parsley.js
+++ b/parsley.js
@@ -895,7 +895,7 @@
       }
 
       // form is invalid, focus an error field depending on focus policy
-      if ( !isValid ) {
+      if ( this.focusedField && !isValid ) {
         this.focusedField.focus();
       }
 


### PR DESCRIPTION
When the focus parameter is set to "none" (as described in the documentation), an error is raised.

This is caused by calling the focus method on the value "false".
