### PR TITLE
Fixed documentation data-equalto

### DIFF
--- a/documentation.html
+++ b/documentation.html
@@ -652,7 +652,7 @@ data-message="You must enter a 10 characters alphanumeric value"</code></pre>
                     <tr>
                         <td>Equal To</td>
                         <td>
-                            <code>data-equalTo="#elem"</code>
+                            <code>data-equalto="#elem"</code>
                         </td>
                         <td>Validates that a value is identical to #elem value. Useful for password repeat validation.</td>
                         <td class="not-for-mobile">


### PR DESCRIPTION
I fixed the documentation, it is suppose to be all lowercase for data-equalto
