### PR TITLE
Adding information about novalidate for HTML5 form

### DIFF
--- a/documentation.html
+++ b/documentation.html
@@ -248,6 +248,10 @@
                 <h3>Parsley Form</h3>
                 <p>This is the main Parsley form validation factory, where you decide if a form is validated, and set some extra options.</p>
                 <pre><code>&lt;form data-validate="parsley">&lt;/form></code></pre>
+                 <div class="alert alert-block alert-info">
+                <span class="label label-important">Heads up!</span> <strong>HTML5</strong>:
+                If you use HTML5 validation feature, add: <code>novalidate</code> attribute to <code>form</code> tag.
+                </div>
                 <h4>Properties</h4>
                 <table class="table table-striped table-bordered table-hover">
                 <thead>


### PR DESCRIPTION
if you use HTML5 validation, chrome/ff/opera will validate form before parsley. Only forcing novalidate will fix that, otherwise only by using js u can validate the form.
