### PR TITLE
Error message shows only once as the item's not removed from container after the animation completed.

### DIFF
--- a/parsley.js
+++ b/parsley.js
@@ -791,9 +791,16 @@
     * @param {String} constraintName Method Name
     */
     , removeError: function ( constraintName ) {
-      var liError = this.ulError + ' .' + constraintName;
+      var liError = this.ulError + ' .' + constraintName
+        , that = this;
 
-      this.options.animate ? $( liError ).fadeOut( this.options.animateDuration, function () { $( this ).remove() } ) : $( liError ).remove();
+      this.options.animate ? $( liError ).fadeOut( this.options.animateDuration, function () { 
+        $( this ).remove(); 
+        
+        if ( that.ulError && $( that.ulError ).children().length === 0 ) 
+        { 
+          that.removeErrors();
+        } } ) : $( liError ).remove();
 
       // remove li error, and ul error if no more li inside
       if ( this.ulError && $( this.ulError ).children().length === 0 ) {


### PR DESCRIPTION
bus in removeError method. When async method fadeOut completes, the removeErrors might already be executed and leave the item in the ul and the container won't show up again
