### PR TITLE
Allow fields to be programaticaly re-validated.

### DIFF
--- a/parsley.js
+++ b/parsley.js
@@ -678,11 +678,6 @@
         return null;
       }
 
-      // do not validate a field already validated and unchanged !
-      if ( !this.needsValidation( val ) ) {
-        return this.valid;
-      }
-
       valid = this.applyValidators();
 
       if ( 'undefined' !== typeof errorBubbling ? errorBubbling : this.options.showErrors ) {


### PR DESCRIPTION
Given two fields Field A and Field B, a validation rule such that Field B must
be greater than the value of Field A.  If both Field A and Field B are filled
and valid.  If the value of Field A is changed; Field B must be re-validated.

The following code:

`$("#field-b").parsley("validate");`

does not cause Field B to be validated.

Removing these lines will fix this problem.
