### PR TITLE
Typo in american date validator

### DIFF
--- a/parsley.extend.js
+++ b/parsley.extend.js
@@ -80,7 +80,7 @@ window.ParsleyConfig = window.ParsleyConfig || {};
       }
 
       , americandate: function ( val, elem, self) {
-        if(!/^([01]?[1-9])[\.\/-]([0-3]?[0-9])[\.\/-]([0-9]{4}|[0-9]{2})$/.test(val)) {
+        if(!/^([01]?[0-9])[\.\/-]([0-3]?[0-9])[\.\/-]([0-9]{4}|[0-9]{2})$/.test(val)) {
         	return false;
         }
         var parts = val.split(/[.\/-]+/);


### PR DESCRIPTION
Fix bug where the following dates won't validate:

10/XX/XXXX
