### PR TITLE
Fix check RegExp if value.length == 0

### DIFF
--- a/parsley.js
+++ b/parsley.js
@@ -122,7 +122,7 @@
         }
 
         // test regExp if not null
-        return '' !== val ? regExp.test( val ) : false;
+        return '' !== val ? regExp.test( val ) : true;
       }
 
       , regexp: function ( val, regExp, self ) {


### PR DESCRIPTION
If input not set to required, val == '' is valid. I think.

If input set required, regexp and val == '' then displayed only required message. This is correct.
![1](https://f.cloud.github.com/assets/3757319/869254/2c9feef0-f7f0-11e2-99bf-efd742ed0385.png)
![2](https://f.cloud.github.com/assets/3757319/869255/31b7930c-f7f0-11e2-8005-9c8b081abd29.png)
