### PR TITLE
Fixed bug with vanishing ul w/ list of errors on field with multiple validations

### DIFF
--- a/parsley.js
+++ b/parsley.js
@@ -768,6 +768,11 @@
         return false;
       }
 
+      // remove li error, and ul error if no more li inside
+      if ( this.ulError && $( this.ulError ).children().length === 0 ) {
+        this.removeErrors();
+      }
+
       return valid;
     }
 
@@ -798,11 +803,6 @@
         if ( that.ulError && $( that.ulError ).children().length === 0 ) {
           that.removeErrors();
         } } ) : $( liError ).remove();
-
-      // remove li error, and ul error if no more li inside
-      if ( this.ulError && $( this.ulError ).children().length === 0 ) {
-        this.removeErrors();
-      }
     }
 
     /**


### PR DESCRIPTION
Hello. Here's the issue: when there's an input with multiple validators like this:

``` html
<input type="text" id="project_name" name="project-name" required="required" data-trigger="change" data-notblank="true" data-maxlength="255"/>
```

when deleting all symbols from the input, the ul element with 'This value is required.' message didn't show up, because of the bug in removeError function. It removes ul element prematurely. There's log from browser's console:

``` sh
manageValidationResult 
Object {notblank: Object, maxlength: Object, required: Object}

checking notblank 
constraint valid? false

checking maxlength 
constraint valid? true 
removing error on: maxlength
removeError
removeErrors

checking required 
constraint valid? false 
addError 
this.valid - false
```

See? The ul is deleted right in the middle of manageValidationResult function, despite it'll be needed on the next step. 

This pull request fixes this bug.

Thanks!
