### PR TITLE
Accept higher jquery versions

### DIFF
--- a/component.json
+++ b/component.json
@@ -3,6 +3,6 @@
   "version": "1.1.16",
   "main": ["./dist/*", "./i18n/*"],
   "dependencies": {
-    "jquery": "1.8.*"
+    "jquery": ">=1.8"
   }
 }


### PR DESCRIPTION
Parsley works fine with jquery versions higher than 1.8. At the moment this constraint prevents me to install jquery 1.9 (with bower version 0.10).

Output of bower:

``` bash
Unable to find a suitable version for jquery
    custom-package requires jquery ~1.9.1
    jquery-pjax requires jquery >=1.8
    parsleyjs requires jquery 1.8.*
    fitvids requires jquery >= 1.7.0

In order to resolve this, you need to do one of two things:
    * Manually add either jquery ~1.9.1, >=1.8, 1.8.* or >= 1.7.0 to your component.json file
    * Run this command again with the --save and --force-latest flags
```
