### PR TITLE
Added scrollDuration option...

### DIFF
--- a/parsley.js
+++ b/parsley.js
@@ -1194,7 +1194,11 @@
         }
       }
 
-      this.options.listeners.onFormSubmit( valid, event, this );
+      // if onFormSubmit returns (bool) false, form won't be submitted, even if valid
+      var onFormSubmit = this.options.listeners.onFormSubmit( valid, event, this );
+      if ('undefined' !== typeof onFormSubmit) {
+        return onFormSubmit;
+      }
 
       return valid;
     }


### PR DESCRIPTION
...to scroll smoothly to the first focused invalid field instead of jumping at it. Focus is set at the end of the scroll.

Hope it helps.
