### PR TITLE
Remove previous errors when require constraint is invalid

### DIFF
--- a/parsley.js
+++ b/parsley.js
@@ -881,6 +881,7 @@
         return;
       // if empty required field and non required constraint fails, do not display
       } else if ( this.isRequired && 'required' !== constraint.name && ( null === this.getVal() || 0 === this.getVal().length ) ) {
+        this.removeError(constraint.name);
         return;
       }
 


### PR DESCRIPTION
I've noticed that in the `manageError` method on line 883 we check to see if the field has already failed validation due to the `required` constraint, if so we don't add all the other errors. The problem is that if some errors were already added to the screen we do not remove them either which breaks the flow.
I've added a call to the `removeError` method in this specific case.
Please let me know if this fix can be pulled asap, as I am reluctant to use a custom version of a library, I'd rather it be an official fix before using the library on our production servers.
Thanks!
