### PR TITLE
Deep clone of Validator.validators on init

### DIFF
--- a/parsley.js
+++ b/parsley.js
@@ -235,6 +235,9 @@
     * Register custom validators and messages
     */
     , init: function ( options ) {
+      // Deep clone of the Validator.validators so each instance has its own copy
+      this.validators = $.extend(true, {}, this.validators)
+
       var customValidators = options.validators
         , customMessages = options.messages;
 


### PR DESCRIPTION
Create a deep clone of Validator.validators on init so each Validator
instance has its own copy instead of sharing a single one.
