### PR TITLE
Added "for" attribute for errorElem if it is the label.

### DIFF
--- a/parsley.js
+++ b/parsley.js
@@ -830,9 +830,14 @@
     */
     , addError: function ( error ) {
       for ( var constraint in error ) {
-        var liTemplate = $( this.options.errors.errorElem ).addClass( constraint );
+        var liTemplate = $( this.options.errors.errorElem ).addClass( constraint ).html( error[ constraint ] );
 
-        $( this.ulError ).append( this.options.animate ? $( liTemplate ).html( error[ constraint ] ).hide().fadeIn( this.options.animateDuration ) : $( liTemplate ).html( error[ constraint ] ) );
+        if ( liTemplate.is( 'label' ) && this.$element.attr( 'id' ) )
+        {
+          liTemplate.attr( 'for', this.$element.attr( 'id' ) );
+        }
+
+        $( this.ulError ).append( this.options.animate ? liTemplate.hide().fadeIn( this.options.animateDuration ) : liTemplate );
       }
     }
 


### PR DESCRIPTION
I think that a good way to use the "for" attribute on labels.
I used ( this.$element.attr( 'id' ) ) instead of ( typeof this.$element.attr( 'id' ) !== 'undefined' ) because second returned true if id="" (empty). It is not correctly.
