### PR TITLE
Fix display:block being added to divs

### DIFF
--- a/parsley.js
+++ b/parsley.js
@@ -907,7 +907,7 @@
     */
     , manageErrorContainer: function () {
       var errorContainer = this.options.errorContainer || this.options.errors.container( this.element, this.isRadioOrCheckbox )
-        , ulTemplate = this.options.animate ? this.ulTemplate.show() : this.ulTemplate;
+        , ulTemplate = this.options.animate ? this.ulTemplate.css('display', '') : this.ulTemplate;
 
       if ( 'undefined' !== typeof errorContainer ) {
         $( errorContainer ).append( ulTemplate );


### PR DESCRIPTION
Parsley adds the css display property with a default value when using .show()

When using jQuery the default value for a div element will be block, ignoring any css markup previously set to the element. This can be fixed by using .css('display', '') instead to reset the display property and use the previous value set on the element.
