### PR TITLE
Update parsley.extend.js

### DIFF
--- a/documentation.html
+++ b/documentation.html
@@ -1141,6 +1141,13 @@ parsley-error-message="You must enter a 10 characters alphanumeric value"</code>
                       Validates that a value is a valid American Date. Allows for slash, dot and hyphen delimiters and condensed dates (e.g., M/D/YY MM.DD.YYYY MM-DD-YY).
                     </td>
                   </tr>
+                  <tr>
+                    <td>DMY Date</td>
+                    <td><code>parsley-dmydate="true"</code></td>
+                    <td>
+                      Validates that a value is a valid DMY Date. Allows two digits only years or four digits years and only slash. Months and days must have two digits (e.g., DD/MM/YY DD/MM/YYYY).
+                    </td>
+                  </tr>
               </tbody>
             </table>
 

--- a/parsley.extend.js
+++ b/parsley.extend.js
@@ -166,8 +166,8 @@ window.ParsleyConfig = window.ParsleyConfig || {};
       , beforedate:     "This date should be before %s."
       , afterdate:      "This date should be after %s."
       , luhn:           "This value should pass the luhn test."
-      , americandate:	"This value should be a valid date (MM/DD/YYYY)."
-      , dmydate:	"This value should be a valid date (DD/MM/YYYY)."
+      , americandate:	  "This value should be a valid date (MM/DD/YYYY)."
+      , dmydate:	      "This value should be a valid date (DD/MM/YYYY)."
     }
   });
 }(window.jQuery || window.Zepto));

--- a/tests/index.html
+++ b/tests/index.html
@@ -260,6 +260,7 @@
 
             <input type="text" id="luhn" parsley-luhn="true" />
             <input type="text" id="americanDate" parsley-americandate="true" />
+            <input type="text" id="dmyDate" parsley-dmydate="true" />
             <input type="text" id="es_dni" parsley-es_dni="true" />
             <input type="text" id="es_cif" parsley-es_cif="true" />
             <input type="text" id="es_postalcode" parsley-es_postalcode="true" />

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -1210,6 +1210,34 @@ var testSuite = function () {
     	 triggerSubmitValidation( '#americanDate', '2.8.12' );
     	 expect( $( '#americanDate' ).hasClass( 'parsley-success' ) ).to.be( true );
        } )
+
+       it ( 'dmyDate', function () {
+       triggerSubmitValidation( '#dmyDate', '02/28/2012' );
+       expect( $( '#dmyDate' ).hasClass( 'parsley-error' ) ).to.be( true );
+       expect( getErrorMessage( '#dmyDate', 'dmyDate') ).to.be( 'This value should be a valid date (DD/MM/YYYY).' );
+       triggerSubmitValidation( '#dmyDate', '02.28.2012' );
+       expect( $( '#dmyDate' ).hasClass( 'parsley-error' ) ).to.be( true );
+       expect( getErrorMessage( '#dmyDate', 'dmyDate') ).to.be( 'This value should be a valid date (DD/MM/YYYY).' );
+       triggerSubmitValidation( '#dmyDate', '2.08.2012' );
+       expect( $( '#dmyDate' ).hasClass( 'parsley-error' ) ).to.be( true );
+       expect( getErrorMessage( '#dmyDate', 'dmyDate') ).to.be( 'This value should be a valid date (DD/MM/YYYY).' );
+       triggerSubmitValidation( '#dmyDate', '02.8.2012' );
+       expect( $( '#dmyDate' ).hasClass( 'parsley-error' ) ).to.be( true );
+       expect( getErrorMessage( '#dmyDate', 'dmyDate') ).to.be( 'This value should be a valid date (DD/MM/YYYY).' );
+       triggerSubmitValidation( '#dmyDate', '02-28-2012' );
+       expect( $( '#dmyDate' ).hasClass( 'parsley-error' ) ).to.be( true );
+       expect( getErrorMessage( '#dmyDate', 'dmyDate') ).to.be( 'This value should be a valid date (DD/MM/YYYY).' );
+       triggerSubmitValidation( '#dmyDate', '2-08-2012' );
+       expect( $( '#dmyDate' ).hasClass( 'parsley-error' ) ).to.be( true );
+       expect( getErrorMessage( '#dmyDate', 'dmyDate') ).to.be( 'This value should be a valid date (DD/MM/YYYY).' );
+       triggerSubmitValidation( '#dmyDate', '02-8-2012' );
+       expect( $( '#dmyDate' ).hasClass( 'parsley-error' ) ).to.be( true );
+       expect( getErrorMessage( '#dmyDate', 'dmyDate') ).to.be( 'This value should be a valid date (DD/MM/YYYY).' );
+       triggerSubmitValidation( '#dmyDate', '02/08/2012' );
+       expect( $( '#dmyDate' ).hasClass( 'parsley-success' ) ).to.be( true );
+       triggerSubmitValidation( '#dmyDate', '02/08/12' );
+       expect( $( '#dmyDate' ).hasClass( 'parsley-success' ) ).to.be( true );
+       } )
      } )
      describe ( 'Test Parsley l10n es', function () {
        it ( 'es_dni', function () {


### PR DESCRIPTION
Added dmydate validator, which will return true only if value is in DD/MM/YYYY format. Note that 2 digits for month and days are required, year can be 4 or 2 digits length. 

Values like: 1/12/1983 or 01/1/1983 will return an error.

Values like: 01/12/1983 or 01/12/83 will return valid.
