### PR TITLE
Fix documentation error on adding custom validator

### DIFF
--- a/documentation.html
+++ b/documentation.html
@@ -1208,8 +1208,13 @@ parsley-error-message="You must enter a 10 characters alphanumeric value"</code>
                         <td  class="not-for-mobile"><p>Add a custom validator that checks if number is a multiple of another:</p>
 <pre><code>$( '#form' ).parsley( {
     validators: {
-      multiple: function ( val, multiple ) {
-        return val % multiple === 0;
+      multiple: function() {
+        return {
+          validate: function(val, multiple) {
+            return val % multiple === 0;
+          },
+          priority: 2
+        };
       }
     }
   , messages: {


### PR DESCRIPTION
The documentation on adding custom validators is outdated to the code. According to this issue (https://github.com/guillaumepotier/Parsley.js/issues/429), you will investigate the problem of priority on the error messages for custom validations. I made the necessary changes in the documentation for who already using the plugin, continue doing it without problems
