### PR TITLE
Auto binding fix to be fully w3c complient

### DIFF
--- a/parsley.js
+++ b/parsley.js
@@ -1445,7 +1445,7 @@
   /* PARSLEY auto-binding
   * =================================================== */
   $( window ).on( 'load', function () {
-    $( '[parsley-validate]' ).each( function () {
+    $( '[parsley-validate], [data-parsley-validate]' ).each( function () {
       $( this ).parsley();
     } );
   } );


### PR DESCRIPTION
The form binding was only possible via [parsley-validate] selector, added the [data-parsley-validate] selector to fully honor the w3c.
