### PR TITLE
Two suggested fixes

### DIFF
--- a/parsley.js
+++ b/parsley.js
@@ -451,6 +451,13 @@
         $( this.ulError ).append( this.options.animate ? $( liTemplate ).html( error[ constraint ] ).hide().fadeIn( this.options.animateDuration ) : $( liTemplate ).html( error[ constraint ] ) );
       }
     }
+    //update existing error messages. 
+    , updateError: function ( error ) {
+      for ( var constraint in error ) {
+        var ul = $( this.ulError );
+        $( this.ulError +  " > li." + constraint).html(error[constraint]);
+      }
+    }
 
     /**
     * Remove all ul / li errors
@@ -513,6 +520,9 @@
       if ( !$( this.ulError + ' .' + liClass ).length ) {
         liError[ liClass ] = message;
         this.addError( liError );
+      } else { //update existing error message in cases where the isValid parameter is unchanged but the error message has changed. 
+        liError[ liClass ] = message;
+        this.updateError( liError );
       }
     }
 


### PR DESCRIPTION
First of all, thanks for an excellent library. A couple of suggested fixes:
1. Allow both 'pattern' and 'parsley-regexp' to be set but the latter to override the former. There is more information in the commented code about my reasoning behind this. 
2. The scenario: I had created a custom validator to validate e-mail addresses. The validator first checks the format of the address. Once the address has the correct format an ajax request is made to the server to make sure the address is not already registered. 
   The problem: If a field was first set to invalid due to an incorrect format and then later set to invalid again, but this time with another error message ("e-mail address already registered"), the message would not be updated in the UI. 
   My fix makes sure that an error message is always updated even if the isValid (or whatever) parameter remains unchanged. I suppose you may want to solve this in a different way, such as changing the addError method instead of adding an updateError method like I did. Your choice. 

It would be great if you could merge these fixes, or possibly improved versions of them, into the next parsley.js release.

Regards,
/Henrik
