### PR TITLE
Browser compatibility bugfix for IE8.

### DIFF
--- a/parsley.extend.js
+++ b/parsley.extend.js
@@ -80,7 +80,7 @@ window.ParsleyConfig = window.ParsleyConfig || {};
             var delimiter = self.options.inlistDelimiter || ',';
             var listItems = (list + "").split(new RegExp("\\s*\\" + delimiter + "\\s*"));
 
-            return (listItems.indexOf(val.trim()) !== -1);
+            return ($.inArray($.trim(val), listItems) !== -1);
           }
           , priority: 32
         }


### PR DESCRIPTION
Array.prototype.indexOf() and String.prototype.trim() do not exist in IE8; use the jQuery versions of those functions.
