### PR TITLE
Fixes issue #474 - Checkbox and radio button groups using custom namespace

### DIFF
--- a/parsley.js
+++ b/parsley.js
@@ -1136,7 +1136,7 @@
       this.$element = $( element );
       this.group = options.group || false;
       this.hash = this.getName();
-      this.siblings = this.group ? '[parsley-group="' + this.group + '"]' : 'input[name="' + this.$element.attr( 'name' ) + '"]';
+      this.siblings = this.group ? '[' + options.namespace + 'group="' + this.group + '"]' : 'input[name="' + this.$element.attr( 'name' ) + '"]';
       this.isRadioOrCheckbox = true;
       this.isRadio = this.$element.is( 'input[type=radio]' );
       this.isCheckbox = this.$element.is( 'input[type=checkbox]' );


### PR DESCRIPTION
In `ParsleyFieldMultiple.initMultiple()` there is the following line...

```
      this.siblings = this.group ? '[parsley-group="' + this.group + '"]' : 'input[name="' + this.$element.attr( 'name' ) + '"]';
```

which I think should be using the `options.namespace` value rather than the hardcoded `parsley-group`...

```
      this.siblings = this.group ? '[' + options.namespace + 'group="' + this.group + '"]' : 'input[name="' + this.$element.attr( 'name' ) + '"]';
```
