### PR TITLE
form.js: Pass form options to fields when being bound

### DIFF
--- a/src/parsley/form.js
+++ b/src/parsley/form.js
@@ -89,7 +89,7 @@ define('parsley/form', [
       this.fields = [];
 
       this.$element.find(this.options.inputs).each(function () {
-        var fieldInstance = new window.Parsley(this, {}, self.parsleyInstance);
+        var fieldInstance = new window.Parsley(this, self.options, self.parsleyInstance);
 
         // Only add valid and not excluded ParsleyField children
         if ('ParsleyField' === fieldInstance.__class__  && !fieldInstance.$element.is(fieldInstance.options.excluded))


### PR DESCRIPTION
"All the options you pass through DOM or constructor for a form will be inherited by every ParsleyField input instance that belongs to the form."

I was trying to pass exclude options through the form config, but the options were not being passed to the form fields. I believe this fixes the issue. Let me know if this is wrong.
