### PR TITLE
Add missing Italian translations

### DIFF
--- a/src/i18n/it.extra.js
+++ b/src/i18n/it.extra.js
@@ -1,0 +1,6 @@
+window.ParsleyConfig = window.ParsleyConfig || {};
+window.ParsleyConfig.i18n = window.ParsleyConfig.i18n || {};
+
+window.ParsleyConfig.i18n.it = $.extend(window.ParsleyConfig.i18n.it || {}, {
+  dateiso: "Inserire una data valida (AAAA-MM-GG)."
+});

--- a/src/i18n/it.js
+++ b/src/i18n/it.js
@@ -22,6 +22,9 @@ window.ParsleyConfig.i18n.it = $.extend(window.ParsleyConfig.i18n.it || {}, {
   minlength:      "Questo valore è troppo corto. La lunghezza minima è di %s caratteri.",
   maxlength:      "Questo valore è troppo lungo. La lunghezza massima è di %s caratteri.",
   length:         "La lunghezza di questo valore deve essere compresa fra %s e %s caratteri.",
+  mincheck:       "Devi scegliere almeno %s opzioni.",
+  maxcheck:       "Devi scegliere al più %s opzioni.",
+  check:          "Devi scegliere tra %s e %s opzioni.",
   equalto:        "Questo valore deve essere identico."
 });
 


### PR DESCRIPTION
Hi there!

I’ve noticed that the Italian i18n was missing some strings (`mincheck`, `maxcheck`, `check`, `dateiso`) so I added them.
