### PR TITLE
Add abbreviation regex

### DIFF
--- a/doc/index.html
+++ b/doc/index.html
@@ -1,4 +1,3 @@
-
 <!DOCTYPE html>
 <html lang="en">
   <head>
@@ -664,7 +663,7 @@
                     </tr>
                   </table>
                 </td>
-                <td>Validates that a value matches a specific regular expression.</td>
+                <td>Validates that a value matches a specific regular expression (regex).</td>
               </tr>
               <tr>
                 <td>


### PR DESCRIPTION
To help those googling or finding in page.

Looks like github's editor also might have removed a dangerous blank line from the start of the file.
