### PR TITLE
Allow passing of extra options with addAsyncValidator function

### DIFF
--- a/src/extra/plugin/remote.js
+++ b/src/extra/plugin/remote.js
@@ -24,10 +24,11 @@ window.ParsleyExtend = $.extend(window.ParsleyExtend, {
     }
   }, window.ParsleyExtend.asyncValidators),
 
-  addAsyncValidator: function (name, fn, url) {
+  addAsyncValidator: function (name, fn, url, options) {
     this.asyncValidators[name.toLowerCase()] = {
       fn: fn,
-      url: url || false
+      url: url || false,
+      options: options || {}
     };
 
     return this;
@@ -178,6 +179,9 @@ window.ParsleyExtend = $.extend(window.ParsleyExtend, {
 
     // Fill data with current value
     data[this.$element.attr('name') || this.$element.attr('id')] = this.getValue();
+
+    // Merge options passed in from the function with the ones in the attribute
+    this.options.remoteOptions = $.extend(true, this.options.remoteOptions || {} , this.asyncValidators[validator].options);
 
     // All `$.ajax(options)` could be overridden or extended directly from DOM in `data-parsley-remote-options`
     ajaxOptions = $.extend(true, {}, {


### PR DESCRIPTION
You can pass in your remote options through the addAsyncValidator function, instead of using the 'data-parsley-remote-options' attribute on the field.

``` javascript
$('[name="q"]').parsley()
  .addAsyncValidator('mycustom', function (xhr) {
    return 404 === xhr.status;
  }, 'http://mycustomapiurl.ext', 
     { "type": "POST", "dataType": "jsonp", "data": { "token": "value" } } 
  );
```
