### PR TITLE
Fixes guillaumepotier/Parsley.js/#649 - Cannot read property '' of undefined

### DIFF
--- a/src/parsley/ui.js
+++ b/src/parsley/ui.js
@@ -388,7 +388,9 @@ define('parsley/ui', [
       if ('ParsleyForm' === parsleyInstance.__class__)
         return;
 
-      parsleyInstance._ui.$errorsWrapper.remove();
+      if ('undefined' !== typeof parsleyInstance._ui)
+        parsleyInstance._ui.$errorsWrapper.remove();
+
       delete parsleyInstance._ui;
     },
 


### PR DESCRIPTION
I was able to reproduce this within my own codebase - possibly something having to do with calling destroy multiple times, or destroy on forms where fields have been removed?  Either way, this defensiveness fixes it.
