### PR TITLE
Correction to the requirementsTransformer call

### DIFF
--- a/src/parsley/factory/constraint.js
+++ b/src/parsley/factory/constraint.js
@@ -21,7 +21,7 @@ define('parsley/factory/constraint', [
 
     // If validator have a requirementsTransformer, execute it
     if ('function' === typeof window.ParsleyValidator.validators[name](requirements).requirementsTransformer)
-      requirements = window.ParsleyValidator.validators[name](requirements).requirementsTransformer();
+      requirements = window.ParsleyValidator.validators[name](requirements).requirementsTransformer(requirements);
 
     return $.extend(window.ParsleyValidator.validators[name](requirements), {
       name: name,


### PR DESCRIPTION
If the callback requirementsTransformer is for "transform" a requirement, I think that the requirement must be passed to the callback.
