### PR TITLE
added explanatory tooltips for abbreviations on front page

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Build Status](https://travis-ci.org/guillaumepotier/Parsley.js.svg?branch=master)](https://travis-ci.org/guillaumepotier/Parsley.js)
 
-Javascript form validation, without actually writing a single line of javascript!
+JavaScript form validation, without actually writing a single line of JavaScript!
 
 ## Version
 

--- a/index.html
+++ b/index.html
@@ -7,7 +7,7 @@
     <meta name="description" content="Parsley, the ultimate frontend javascript form validation library">
     <meta name="author" content="Guillaume Potier">
 
-    <title>Parsley - The ultimate javascript form validation library</title>
+    <title>Parsley - The ultimate JavaScript form validation library</title>
 
     <!-- Bootstrap core CSS -->
     <link href="bower_components/bootstrap/dist/css/bootstrap.css" rel="stylesheet">
@@ -94,7 +94,7 @@
           <h3 class="text-muted"><a href="#">Parsley</a></h3>
 
           <span class="social-buttons inline-block">
-            <a href="https://twitter.com/share" class="twitter-share-button" data-url="http://parsleyjs.org" data-text="Parsley, the ultimate javascript form validation library. #parsleyjs" data-via="guillaumepotier" data-related="guillaumepotier" data-hashtags="parsleyjs">Tweet</a>
+            <a href="https://twitter.com/share" class="twitter-share-button" data-url="http://parsleyjs.org" data-text="Parsley, the ultimate JavaScript form validation library. #parsleyjs" data-via="guillaumepotier" data-related="guillaumepotier" data-hashtags="parsleyjs">Tweet</a>
             <script>!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0],p=/^http:/.test(d.location)?'http':'https';if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src=p+'://platform.twitter.com/widgets.js';fjs.parentNode.insertBefore(js,fjs);}}(document, 'script', 'twitter-wjs');</script>
 
             <iframe src="http://ghbtns.com/github-btn.html?user=guillaumepotier&repo=Parsley.js&type=watch&count=true" allowtransparency="true" frameborder="0" scrolling="0" width="110" height="20"></iframe>
@@ -117,7 +117,7 @@
 
       <!-- Jumbotron -->
       <div class="jumbotron">
-        <h1><em>Parsley</em>, the <strong>ultimate</strong> javascript <strong>form validation</strong> library</h1>
+        <h1><em>Parsley</em>, the <strong>ultimate</strong> JavaScript <strong>form validation</strong> library</h1>
         <p class="lead">Validating forms frontend have never been so <em>powerful</em> and <em>easy</em>.</p>
         <p><a class="btn btn-lg btn-go" href="doc/index.html" role="button">Get started today</a></p>
         <p class="version"><i class="icon glyphicon glyphicon-tag"></i>&nbsp;v2.0.2</p>
@@ -128,7 +128,7 @@
 
         <div class="col-lg-4">
           <h2>Intuitive DOM API</h2>
-          <p class="argument">Like no other form validation library, simply <strong>write in English your requirements inside your form HTML tags</strong>, Parsley will do the rest! <strong>No need to write even a single javascript line for simple form validation.</strong></p>
+          <p class="argument">Like no other form validation library, simply <strong>write in English your requirements inside your form HTML tags</strong>, Parsley will do the rest! <strong>No need to write even a single JavaScript line for simple form validation.</strong></p>
           <p><a href="doc/examples.html">View example &raquo;</a></p>
        </div>
         <div class="col-lg-4">


### PR DESCRIPTION
while not crucial, this seems like a nice detail to have

aside: the hashtag format seems more confusing than helpful to me - though it might make sense if the hashtags were actual links
