### PR TITLE
Fix #702, adding plugin context to asyncValidators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Parsley 2.x changelog
 
+
+  - added ParsleyField context to asyncValidator callback functions (#702)
+
 ## 2.0.3
 
   - fix not AMD loading for Wordpress case (#685)

--- a/doc/index.html
+++ b/doc/index.html
@@ -1008,7 +1008,9 @@ window.ParsleyValidator
             <tr>
               <td>Validator</td>
               <td><code>data-parsley-remote-validator</code> <version>#2.0</version></td>
-              <td>Use a specific remote validator. By default, there are 2 built-in remote validators: <code>default</code> and <code>reverse</code>. Default one is used by default and Reverse one used when <code>data-parsley-remote-reverse</code> is set to true. (this is an alias, you could use <code>data-parsley-remote-validator="reverse"</code>). To learn how to craft your custom remote validators, go <a href="#remote-custom">here</a>.</td>
+              <td><p>Use a specific remote validator. By default, there are 2 built-in remote validators: <code>default</code> and <code>reverse</code>. Default one is used by default and Reverse one used when <code>data-parsley-remote-reverse</code> is set to true. (this is an alias, you could use <code>data-parsley-remote-validator="reverse"</code>).</p>
+                  <p>Inside the function, <code>this</code> keyword refers to the <code>ParsleyField</code> instance attached to the form element. You have access to the plugin as well as the element if you need to perform other actions before returning the validation result.</p>
+                  <p>To learn how to craft your custom remote validators, go <a href="#remote-custom">here</a>.</p></td>
             </tr>
           </tbody>
         </table>
@@ -1049,6 +1051,8 @@ window.ParsleyExtend = {
   asyncValidators: {
     mycustom: {
       fn: function (xhr) {
+        console.log(this.$element); // jQuery Object[ input[name="q"] ]
+
         return 404 === xhr.status;
       },
       url: 'http://mycustomapiurl.ext'
@@ -1068,6 +1072,8 @@ window.ParsleyExtend = {
 &lt;script type="text/javascript">
 $('[name="q"]').parsley()
   .addAsyncValidator('mycustom', function (xhr) {
+    console.log(this.$element); // jQuery Object[ input[name="q"] ]
+
     return 404 === xhr.status;
   }, 'http://mycustomapiurl.ext');
 &lt;/script>

--- a/src/extra/plugin/remote.js
+++ b/src/extra/plugin/remote.js
@@ -225,7 +225,7 @@ window.ParsleyExtend = $.extend(window.ParsleyExtend, {
 
   _handleRemoteResult: function (validator, xhr, deferred) {
     // If true, simply resolve and exit
-    if ('function' === typeof this.asyncValidators[validator].fn && this.asyncValidators[validator].fn(xhr)) {
+    if ('function' === typeof this.asyncValidators[validator].fn && this.asyncValidators[validator].fn.call(this, xhr)) {
       deferred.resolveWith(this);
 
       return;

--- a/test/features/remote.js
+++ b/test/features/remote.js
@@ -2,7 +2,7 @@ define('features/remote', [
   'extra/plugin/remote',
 ], function (ParsleyExtend) {
 
-  // Preseve ParsleyExtend in order to load it only when needed by this suite and do not alter other tests runned before
+  // Preserve ParsleyExtend in order to load it only when needed by this suite and do not alter other tests run before
   window._remoteParsleyExtend = window.ParsleyExtend;
   window._remoteParsleyConfig = window.ParsleyConfig;
   window.ParsleyExtend = window.ParsleyExtend || {};
@@ -120,7 +120,7 @@ define('features/remote', [
             done();
           });
       });
-      it('should save some calls for querries already done', function (done) {
+      it('should save some calls for queries already done', function (done) {
         $('body').append('<input type="text" data-parsley-remote="http://foo.bar" id="element" required name="element" value="foo" />');
         var parsleyInstance = $('#element').parsley();
 
@@ -178,7 +178,6 @@ define('features/remote', [
               });
           });
       });
-
       it('should handle remote validator option with custom url', function (done) {
         $('body').append('<input type="text" data-parsley-remote id="element" data-parsley-remote-validator="mycustom" required name="element" value="foobar" />');
         var parsleyInstance = $('#element').parsley();
@@ -195,7 +194,22 @@ define('features/remote', [
             done();
           });
       });
+      it('should have PluginField as the `this` context of the AJAX callback', function(done) {
+        $('body').append('<input type="text" data-parsley-remote id="element" data-parsley-remote-validator="mycustom" required name="element" value="foobar" />');
+        var parsleyInstance = $('#element').parsley();
 
+        parsleyInstance.addAsyncValidator('mycustom', function (xhr) {
+          expect(this.__class__).to.be('ParsleyField');
+        }, 'http://foobar.baz');
+
+        sinon.stub($, 'ajax').returns($.Deferred().resolve({}, 'success', { status: 200, state: function () { return 'resolved' } }));
+        parsleyInstance.asyncIsValid()
+          .fail(function () {
+            expect($.ajax.calledWithMatch({ url: "http://foobar.baz" })).to.be(true);
+            $.ajax.restore();
+            done();
+          });
+      });
       it.skip('should abort successives querries and do not handle their return');
       afterEach(function () {
         if ($('#element').length)

--- a/test/tests.js
+++ b/test/tests.js
@@ -73,7 +73,7 @@ require(['config'], function () {
             // beforeEach(function () {
             //   window.ParsleyConfig = $.extend(true, {}, window.ParsleyConfig, { excluded: 'input[type=button], input[type=submit], input[type=reset], input[type=hidden], input[disabled]' });
             // });
-            remote();
+            remote(ParsleyExtend);
             abstract(Parsley);
             field(ParsleyField, Parsley);
             form(ParsleyForm, Parsley);


### PR DESCRIPTION
Fix #702, adding plugin context to asyncValidators

Remove commented/replaced line

Merge branch 'master' of github.com:cautionbug/Parsley.js

Conflicts:
    src/extra/plugin/remote.js

Remove commented/replaced line
- Fix issue #702 to give ParsleyField context to asyncValidator callbacks
- Updated test.js to pass ParsleyExtend to remote()
- Added test to remote.js to test `this` context within asyncValidator callback
- Updated documentation about `data-parsley-remote-validator` to explain `this` context, and updated code example.

Fix #702, adding plugin context to asyncValidators

Fix #702, adding plugin context to asyncValidators

Remove commented/replaced line

Merge branch 'master' of github.com:cautionbug/Parsley.js

Conflicts:
    src/extra/plugin/remote.js

Remove commented/replaced line

Merge branch 'master' of github.com:cautionbug/Parsley.js

Update CHANGELOG.md

Didn't set a release number so original project can determine that when
other patches are merged for a release.

Fix #702, adding plugin context to asyncValidators

Fix #702, adding plugin context to asyncValidators

Remove commented/replaced line

Merge branch 'master' of github.com:cautionbug/Parsley.js

Conflicts:
    src/extra/plugin/remote.js

Remove commented/replaced line

Fix #702, adding plugin context to asyncValidators

Fix #702, adding plugin context to asyncValidators

Remove commented/replaced line

Merge branch 'master' of github.com:cautionbug/Parsley.js

Conflicts:
    src/extra/plugin/remote.js

Remove commented/replaced line

Merge branch 'master' of github.com:cautionbug/Parsley.js

Merge branch 'master' of https://github.com/cautionbug/Parsley.js

Update CHANGELOG.md

Didn't set a release number so original project can determine that when
other patches are merged for a release.

Fix #702, adding plugin context to asyncValidators

Fix #702, adding plugin context to asyncValidators

Remove commented/replaced line

Merge branch 'master' of github.com:cautionbug/Parsley.js

Conflicts:
    src/extra/plugin/remote.js

Remove commented/replaced line
- Fix issue #702 to give ParsleyField context to asyncValidator callbacks
- Updated test.js to pass ParsleyExtend to remote()
- Added test to remote.js to test `this` context within asyncValidator callback
- Updated documentation about `data-parsley-remote-validator` to explain `this` context, and updated code example.

Fix #702, adding plugin context to asyncValidators

Fix #702, adding plugin context to asyncValidators

Remove commented/replaced line

Merge branch 'master' of github.com:cautionbug/Parsley.js

Conflicts:
    src/extra/plugin/remote.js

Remove commented/replaced line

Merge branch 'master' of github.com:cautionbug/Parsley.js

Update CHANGELOG.md

Didn't set a release number so original project can determine that when
other patches are merged for a release.

Fix #702, adding plugin context to asyncValidators

Fix #702, adding plugin context to asyncValidators

Remove commented/replaced line

Merge branch 'master' of github.com:cautionbug/Parsley.js

Conflicts:
    src/extra/plugin/remote.js

Remove commented/replaced line
- Fix issue #702 to give ParsleyField context to asyncValidator callbacks
- Updated test.js to pass ParsleyExtend to remote()
- Added test to remote.js to test `this` context within asyncValidator callback
- Updated documentation about `data-parsley-remote-validator` to explain `this` context, and updated code example.

Fix #702, adding plugin context to asyncValidators

Update CHANGELOG.md

Didn't set a release number so original project can determine that when
other patches are merged for a release.
