### PR TITLE
adds var key word to validator declaration

### DIFF
--- a/src/parsley/validator.js
+++ b/src/parsley/validator.js
@@ -3,7 +3,7 @@ define('parsley/validator', [
 ], function (Validator) {
 
   // This is needed for Browserify usage that requires Validator.js through module.exports
-  Validator = 'undefined' !== typeof Validator ? Validator : module.exports;
+  var Validator = 'undefined' !== typeof Validator ? Validator : module.exports;
 
   var ParsleyValidator = function (validators, catalog) {
     this.__class__ = 'ParsleyValidator';


### PR DESCRIPTION
The lack of a var keyword can cause errors in stricter JS engines, I was having a problem including this through the karma-browserify preprocessor without it.
