### PR TITLE
Symplify jQuery ready. Align validator

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -11,8 +11,7 @@
     "*.html",
     "AUTHORS.txt",
     "Gruntfile.js",
-    "package.json",
-    "bower.json"
+    "package.json"
   ],
   "devDependencies": {
     "jquery": "~1.10.0",
@@ -35,5 +34,5 @@
     "url": "http://guillaumepotier.com/"
   },
   "license": "MIT",
-  "main": "./dist/parsley.js"
+  "main": "dist/parsley.js"
 }

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "homepage": "http://parsleyjs.org",
   "license": "MIT",
   "description": "Validate your forms, frontend, without writing a single line of javascript!",
-  "main": "./dist/parsley.js",
+  "main": "dist/parsley.js",
   "repository": {
     "type": "git",
     "url": "https://github.com/guillaumepotier/Parsley.js.git"

--- a/src/parsley.js
+++ b/src/parsley.js
@@ -263,7 +263,7 @@ define([
   // ### PARSLEY auto-binding
   // Prevent it by setting `ParsleyConfig.autoBind` to `false`
   if (false !== ParsleyUtils.get(window, 'ParsleyConfig.autoBind'))
-    $(document).ready(function () {
+    $(function () {
       // Works only on `data-parsley-validate`.
       if ($('[data-parsley-validate]').length)
         $('[data-parsley-validate]').parsley();

--- a/src/parsley/validator.js
+++ b/src/parsley/validator.js
@@ -171,11 +171,11 @@ define('parsley/validator', [
       },
       maxlength: function (value) {
         return $.extend(new Validator.Assert().Length({ max: value }), {
-        priority: 30,
-        requirementsTransformer: function () {
+          priority: 30,
+          requirementsTransformer: function () {
             return 'string' === typeof value && !isNaN(value) ? parseInt(value, 10) : value;
           }
-      });
+        });
       },
       length: function (array) {
         return $.extend(new Validator.Assert().Length({ min: array[0], max: array[1] }), { priority: 32 });


### PR DESCRIPTION
1. Use shorthand for $( document ).ready() (http://learn.jquery.com/using-jquery-core/document-ready).
2. Bower always leaves bower.json (for test: bower install parsleyjs).
