### PR TITLE
Remove filled class from errors ul when reseting

### DIFF
--- a/src/parsley/ui.js
+++ b/src/parsley/ui.js
@@ -374,6 +374,7 @@ define('parsley/ui', [
       parsleyInstance._ui.$errorsWrapper.children().each(function () {
         $(this).remove();
       });
+      parsleyInstance._ui.$errorsWrapper.removeClass('filled');
 
       // Reset validation class
       this._resetClass(parsleyInstance);

--- a/test/features/ui.js
+++ b/test/features/ui.js
@@ -271,6 +271,13 @@ define(function () {
         var parsleyInstance = $('#element').parsley();
         expect($('body ul').length).to.be(0);
       });
+      it('should remove filled class from errors container when reseting', function () {
+        $('body').append('<input type="email" id="element" value="foo" data-parsley-minlength="5" />');
+        var parsleyInstance = $('#element').parsley();
+        parsleyInstance.validate();
+        parsleyInstance.reset();
+        expect($('ul#parsley-id-' + parsleyInstance.__id__).hasClass('filled')).to.be(false);
+      });
       afterEach(function () {
         if ($('#element').length)
           $('#element').remove();


### PR DESCRIPTION
Calling reset removes the error `<li>`s, but leaves the empty `<ul>`.

![screen shot 2014-09-23 at 12 08 30 pm](https://cloud.githubusercontent.com/assets/310707/4375405/f9d7f704-433b-11e4-8592-dc777579554c.png)

This fixes https://github.com/guillaumepotier/Parsley.js/issues/626 and https://github.com/guillaumepotier/Parsley.js/issues/734
