### PR TITLE
Updated with improved Danish translation

### DIFF
--- a/src/i18n/da.js
+++ b/src/i18n/da.js
@@ -6,22 +6,22 @@ window.ParsleyConfig.i18n = window.ParsleyConfig.i18n || {};
 window.ParsleyConfig.i18n.da = $.extend(window.ParsleyConfig.i18n.da || {}, {
   defaultMessage: "Indtast venligst en korrekt værdi.",
   type: {
-    email:        "Indtast venligst en korrekt email.",
+    email:        "Indtast venligst en korrekt emailadresse.",
     url:          "Indtast venligst en korrekt internetadresse.",
-    number:       "Indtast venligst et korrekt nummer.",
-    integer:      "Indtast venligst et korrekt tal.",
+    number:       "Indtast venligst et tal.",
+    integer:      "Indtast venligst et heltal.",
     digits:       "Dette felt må kun bestå af tal.",
     alphanum:     "Dette felt skal indeholde både tal og bogstaver."
   },
   notblank:       "Dette felt må ikke være tomt.",
   required:       "Dette felt er påkrævet.",
   pattern:        "Ugyldig indtastning.",
-  min:            "Dette felt skal indeholde mindst %s tegn.",
-  max:            "Dette felt kan højest indeholde %s tegn.",
-  range:          "Dette felt skal være mellem %s og %s tegn.",
+  min:            "Dette felt skal indeholde et tal som er større end eller lig med %s.",
+  max:            "Dette felt skal indeholde et tal som er mindre end eller lig med %s.",
+  range:          "Dette felt skal indeholde et tal mellem %s og %s.",
   minlength:      "Indtast venligst mindst %s tegn.",
-  maxlength:      "Dette felt kan kun indeholde %s tegn.",
-  length:         "This value length is invalid. It should be between %s and %s characters long.",
+  maxlength:      "Dette felt kan højst indeholde %s tegn.",
+  length:         "Længden af denne værdi er ikke korrekt. Værdien skal være mellem %s og %s tegn lang.",
   mincheck:       "Vælg mindst %s muligheder.",
   maxcheck:       "Vælg op til %s muligheder.",
   check:          "Vælg mellem %s og %s muligheder.",
@@ -31,3 +31,4 @@ window.ParsleyConfig.i18n.da = $.extend(window.ParsleyConfig.i18n.da || {}, {
 // If file is loaded after Parsley main file, auto-load locale
 if ('undefined' !== typeof window.ParsleyValidator)
   window.ParsleyValidator.addCatalog('da', window.ParsleyConfig.i18n.da, true);
+  


### PR DESCRIPTION
The original translation had for instance translated min and max for number as min and max length values for a string which made the error message confusing.
