### PR TITLE
Add spm support

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,5 +39,13 @@
   "scripts": {
     "test": "mocha-phantomjs test/index.html",
     "test-all": "mocha-phantomjs test/index.html && mocha-phantomjs test/env/amd.html && mocha-phantomjs test/env/browserify.html"
+  },
+  "spm": {
+    "main": "dist/parsley.js",
+    "ignore": [
+      "doc",
+      "test",
+      "src"
+    ]
   }
 }


### PR DESCRIPTION
A nicer package manager: http://spmjs.io
Documentation: http://spmjs.io/documentation

http://spmjs.io/package/parsleyjs

---

It is a package manager based on [Sea.js](https://github.com/seajs/seajs) which is a popular module loader in China.

spmjs focus in browser side. We supply a complete lifecycle managment of package by using [spm](https://github.com/spmjs/spm/tree/master).

> If you need ownership of parsleyjs in spmjs, I can add it for your account after signing in http://spmjs.io.
