### PR TITLE
Can validate select with no options

### DIFF
--- a/src/parsley/field.js
+++ b/src/parsley/field.js
@@ -65,7 +65,7 @@ define('parsley/field', [
 
       // If a field is empty and not required, leave it alone, it's just fine
       // Except if `data-parsley-validate-if-empty` explicitely added, useful for some custom validators
-      if ((!value.length || 0 === value.length) && !this._isRequired() && 'undefined' === typeof this.options.validateIfEmpty && true !== force)
+      if (!value.length && !this._isRequired() && 'undefined' === typeof this.options.validateIfEmpty && true !== force)
         return this.validationResult = [];
 
       // If we want to validate field against all constraints, just call Validator and let it do the job


### PR DESCRIPTION
Combining parsley.js with other libraries such as selectize.js, no selected options will result in an empty select. To not have the validator throw an error, this fix ensures that even if the value does not have the property `length`, things will run ok.
