### PR TITLE
Remove -ms-transition

### DIFF
--- a/src/parsley.css
+++ b/src/parsley.css
@@ -26,7 +26,6 @@ textarea.parsley-error {
 
   transition: all .3s ease-in;
   -o-transition: all .3s ease-in;
-  -ms-transition: all .3s ease-in;
   -moz-transition: all .3s ease-in;
   -webkit-transition: all .3s ease-in;
 }


### PR DESCRIPTION
-ms-transition is unnecessary; transitions are not supported in IE9; IE10 supports the prefixless variant.

Reference: http://caniuse.com/#feat=css-transitions
