### PR TITLE
wrapped *default* key in quotes as it's a reserved word

### DIFF
--- a/src/extra/plugin/remote.js
+++ b/src/extra/plugin/remote.js
@@ -9,7 +9,7 @@ window.ParsleyExtend = $.extend(window.ParsleyExtend, {
   asyncSupport: true,
 
   asyncValidators: $.extend({
-    default: {
+    'default': {
       fn: function (xhr) {
         return 'resolved' === xhr.state();
       },


### PR DESCRIPTION
_default_ is a reserved word and was breaking on IE < 10.
