### PR TITLE
Fix tests for minlength and max_length

### DIFF
--- a/test/features/validator.js
+++ b/test/features/validator.js
@@ -121,13 +121,13 @@ define(function () {
       it('should have a minlength validator', function () {
         expect(parsleyValidator.validate('foo', parsleyValidator.validators.minlength(3))).to.be(true);
         expect(parsleyValidator.validate('fo', parsleyValidator.validators.minlength(3))).not.to.be(true);
-        $('body').append('<input type="text" id="element" value="foo" minlength="2" />');
+        $('body').append('<input type="text" id="element" value="foo" data-parsley-minlength="2" />');
         expect($('#element').parsley().isValid()).to.be(true);
       });
       it('should have a maxlength validator', function () {
         expect(parsleyValidator.validate('foo', parsleyValidator.validators.maxlength(3))).to.be(true);
         expect(parsleyValidator.validate('foobar', parsleyValidator.validators.maxlength(3))).not.to.be(true);
-        $('body').append('<input type="text" id="element" value="foo" maxlength="10" />');
+        $('body').append('<input type="text" id="element" value="foo" data-parsley-maxlength="10" />');
         expect($('#element').parsley().isValid()).to.be(true);
       });
       it('should have a check validator', function () {


### PR DESCRIPTION
Although there is a `minlength` and a `maxlength` HTML5 validation attribute, there is no binding currently in Parsley and that's also what the doc says.

So I've fixed these two tests that didn't actually test what they meant, but I'm wondering: is there a reason why there isn't a binding with the `minlength` and `maxlength` attributes?
