### PR TITLE
Validated with result

### DIFF
--- a/doc/index.html
+++ b/doc/index.html
@@ -907,10 +907,22 @@ window.ParsleyValidator
               <td>Fired when a form validation is triggered, <strong>before</strong> its validation.</td>
             </tr>
             <tr>
+              <td><code>parsley:form:success</code> <version>#2.0</version></td>
+              <td><code>ParsleyForm</code></td>
+              <td><code>.validate()</code></td>
+              <td>Fired when a form validation is triggered, <strong>after</strong> its validation succeeds.</td>
+            </tr>
+            <tr>
+              <td><code>parsley:form:error</code> <version>#2.0</version></td>
+              <td><code>ParsleyForm</code></td>
+              <td><code>.validate()</code></td>
+              <td>Fired when a form validation is triggered, <strong>after</strong> its validation fails.</td>
+            </tr>
+            <tr>
               <td><code>parsley:form:validated</code> <version>#2.0</version></td>
               <td><code>ParsleyForm</code></td>
               <td><code>.validate()</code></td>
-              <td>Fired when a form validation is triggered, <strong>after</strong> its validation.</td>
+              <td>Fired when a form validation is triggered, <strong>after</strong> its validation finishes (with success or with errors).</td>
             </tr>
             <tr>
               <td><code>parsley:field:init</code> <version>#2.0</version></td>

--- a/src/extra/plugin/remote.js
+++ b/src/extra/plugin/remote.js
@@ -104,6 +104,12 @@ window.ParsleyExtend = $.extend(window.ParsleyExtend, {
     }
 
     return $.when.apply($, promises)
+      .done(function () {
+        $.emit('parsley:form:success', that);
+      })
+      .fail(function () {
+        $.emit('parsley:form:error', that);
+      })
       .always(function () {
         $.emit('parsley:form:validated', that);
       });

--- a/src/parsley/form.js
+++ b/src/parsley/form.js
@@ -54,6 +54,7 @@ define('parsley/form', [
           this.validationResult = false;
       }
 
+      $.emit('parsley:form:' + this.validationResult ? 'success' : 'error', this);
       $.emit('parsley:form:validated', this);
 
       return this.validationResult;

--- a/test/features/form.js
+++ b/test/features/form.js
@@ -151,6 +151,24 @@ define(function () {
         expect(formInstance.fields[0].$element.attr('id')).to.be('email');
         expect(fieldInstance.parent.__class__).to.be('ParsleyForm');
       });
+      it('should fire the right callbacks in the right order', function () {
+        var $form = $('<form><input type="string" required /><form>').appendTo($('body'));
+        $form.on('submit', function (e) {
+          e.preventDefault();
+        });
+
+        var callbacks = [];
+        var parsleyInstance = $form.parsley();
+        $.each(['validate', 'error', 'success', 'validated'], function(i, cb) {
+          parsleyInstance.subscribe('parsley:form:' + cb, function() {
+            callbacks.push(cb);
+          });
+        });
+        $form.submit();
+        $form.find('input').val('Hello');
+        $form.submit();
+        expect(callbacks.join()).to.be('validate,error,validated,validate,success,validated');
+      });
       it('should stop event propagation on form submit', function (done) {
         $('body').append('<form id="element"><input type="text" required/></form>');
         var parsleyInstance = $('#element').parsley();


### PR DESCRIPTION
Having callbacks `'parsley:form:success'` and `'parsley:form:error'` would be helpful and consistent with corresponding callbacks for fields.

My patch also adds doc that was absent for the `'parsley:field:validated'` event.
