### PR TITLE
Field is valid

### DIFF
--- a/src/parsley/field.js
+++ b/src/parsley/field.js
@@ -52,7 +52,9 @@ define('parsley/field', [
     },
 
     // Just validate field. Do not trigger any event
-    // Same @return as `validate()`
+    //  - `true` if all constraint passes
+    //  - `[]` if not required field and empty (not validated)
+    //  - `false` if there were validation errors
     isValid: function (force, value) {
       // Recompute options and rebind constraints to have latest changes
       this.refreshConstraints();

--- a/src/parsley/field.js
+++ b/src/parsley/field.js
@@ -61,15 +61,18 @@ define('parsley/field', [
 
       // Sort priorities to validate more important first
       var priorities = this._getConstraintsSortedPriorities();
+
+      this.validationResult = [];
       if (0 === priorities.length)
-        return this.validationResult = [];
+        return true;
+
       // Value could be passed as argument, needed to add more power to 'parsley:field:validate'
       value = value || this.getValue();
 
       // If a field is empty and not required, leave it alone, it's just fine
       // Except if `data-parsley-validate-if-empty` explicitely added, useful for some custom validators
       if (!value.length && !this._isRequired() && 'undefined' === typeof this.options.validateIfEmpty && true !== force)
-        return this.validationResult = [];
+        return [];
 
       // If we want to validate field against all constraints, just call Validator and let it do the job
       if (false === this.options.priorityEnabled)

--- a/test/features/field.js
+++ b/test/features/field.js
@@ -66,14 +66,14 @@ define(function () {
         expect(parsleyField.constraints[0].name).to.be('notblank');
         expect(parsleyField._isRequired()).to.be(false);
       });
-      it('should return an empty array for fields withoud constraints', function () {
+      it('should return true for fields without constraints', function () {
         $('body').append('<input type="text" id="element" value="hola" data-parsley-minlength="5" />');
         var parsleyField = new Parsley($('#element'));
         // Start with some validation errors:
         expect(parsleyField.isValid()).to.eql(false);
         // The remove constraint and check result:
         $('#element').removeAttr('data-parsley-minlength');
-        expect(parsleyField.isValid()).to.eql([]);
+        expect(parsleyField.isValid()).to.be(true);
       });
       it('should properly bind HTML5 supported constraints', function () {
         $('body').append('<input type="email" pattern="\\w+" id="element" required min="5" max="100" />');


### PR DESCRIPTION
Return `true` instead of `[]` when there are no validations.
Fix invalid doc for `Field#isValid` and make it clearer when `[]` is returned.