### PR TITLE
Store violation list in validationResult

### DIFF
--- a/test/features/form.js
+++ b/test/features/form.js
@@ -54,7 +54,7 @@ define(function () {
           '</form>');
           var parsleyForm = new Parsley($('#element'));
           parsleyForm.validate();
-          expect(parsleyForm.validationResult).to.be(false);
+          expect(parsleyForm.validationResult.length).to.be(2);
           $('#field1').val('foo');
           $('#field3').val('foo');
           expect(parsleyForm.validate()).to.be(true);


### PR DESCRIPTION
There is no easy way to get the list of violations after a call to `parsleyForm.validate()`, but I think it would be very useful.

This PR stores the list of violations in `form.validationResult`.
This is potentially a breaking change, though, if anyone depends on `form.validationResult` being `false`. As it isn't documented, I thought it's ok, but maybe we better add another attribute instead (`violations`?).
