### PR TITLE
Emit 'parsley:form:validate' before refreshing the fields

### DIFF
--- a/src/parsley/form.js
+++ b/src/parsley/form.js
@@ -36,10 +36,10 @@ define('parsley/form', [
 
       var fieldValidationResult = [];
 
+      $.emit('parsley:form:validate', this);
+
       // Refresh form DOM options and form's fields that could have changed
       this._refreshFields();
-
-      $.emit('parsley:form:validate', this);
 
       // loop through fields to validate them one by one
       for (var i = 0; i < this.fields.length; i++) {

--- a/test/features/form.js
+++ b/test/features/form.js
@@ -169,6 +169,13 @@ define(function () {
         $form.submit();
         expect(callbacks.join()).to.be('validate,error,validated,validate,success,validated');
       });
+      it('should fire "parsley:form:validate" to give the opportunity for changes before validation occurs', function() {
+        var $form = $('<form><input type="string" required /><form>').appendTo($('body'));
+        $form.parsley().subscribe('parsley:form:validate', function(psly) {
+          psly.$element.find('input').remove();
+        });
+        expect($form.parsley().validate()).to.be(true);
+      });
       it('should stop event propagation on form submit', function (done) {
         $('body').append('<form id="element"><input type="text" required/></form>');
         var parsleyInstance = $('#element').parsley();


### PR DESCRIPTION
This PR is to give the opportunity to change stuff before validation occurs, including things that would affect Form#_refreshFields.
