### PR TITLE
Fix field creation problems

### DIFF
--- a/src/parsley.js
+++ b/src/parsley.js
@@ -72,11 +72,8 @@ define([
       if (this.$element.is('form') || (ParsleyUtils.attr(this.$element, this.options.namespace, 'validate') && !this.$element.is(this.options.inputs)))
         return this.bind('parsleyForm');
 
-      // Every other supported element and not excluded element is binded as a `ParsleyField` or `ParsleyFieldMultiple`
-      else if (this.$element.is(this.options.inputs) && !this.$element.is(this.options.excluded))
-        return this.isMultiple() ? this.handleMultiple(parsleyFormInstance) : this.bind('parsleyField', parsleyFormInstance);
-
-      return this;
+      // Every other element is binded as a `ParsleyField` or `ParsleyFieldMultiple`
+      return this.isMultiple() ? this.handleMultiple(parsleyFormInstance) : this.bind('parsleyField', parsleyFormInstance);
     },
 
     isMultiple: function () {

--- a/src/parsley/ui.js
+++ b/src/parsley/ui.js
@@ -246,12 +246,6 @@ define('parsley/ui', [
       // Store it in fieldInstance for later
       fieldInstance._ui = _ui;
 
-      // Stops excluded inputs from getting errorContainer added
-      if( !fieldInstance.$element.is(fieldInstance.options.excluded) ) {
-        /** Mess with DOM now **/
-        this._insertErrorWrapper(fieldInstance);
-      }
-
       // Bind triggers first time
       this.actualizeTriggers(fieldInstance);
     },

--- a/src/parsley/ui.js
+++ b/src/parsley/ui.js
@@ -78,6 +78,8 @@ define('parsley/ui', [
       // Case where we have errorMessage option that configure an unique field error message, regardless failing validators
       if ('undefined' !== typeof fieldInstance.options.errorMessage) {
         if ((diff.added.length || diff.kept.length)) {
+          this._insertErrorWrapper(fieldInstance);
+
           if (0 === fieldInstance._ui.$errorsWrapper.find('.parsley-custom-error-message').length)
             fieldInstance._ui.$errorsWrapper
               .append(
@@ -111,6 +113,7 @@ define('parsley/ui', [
     // TODO: strange API here, intuitive for manual usage with addError(pslyInstance, 'foo', 'bar')
     // but a little bit complex for above internal usage, with forced undefined parameter...
     addError: function (fieldInstance, name, message, assert, doNotUpdateClass) {
+      this._insertErrorWrapper(fieldInstance);
       fieldInstance._ui.$errorsWrapper
         .addClass('filled')
         .append(
@@ -276,6 +279,10 @@ define('parsley/ui', [
 
     _insertErrorWrapper: function (fieldInstance) {
       var $errorsContainer;
+
+      // Nothing to do if already inserted
+      if (0 !== fieldInstance._ui.$errorsWrapper.parent().length)
+        return fieldInstance._ui.$errorsWrapper.parent();
 
       if ('string' === typeof fieldInstance.options.errorsContainer) {
         if ($(fieldInstance.options.errorsContainer).length)

--- a/test/features/parsley.js
+++ b/test/features/parsley.js
@@ -24,18 +24,17 @@ define(function () {
         expect(parsleyInstance).to.be.an('object');
         expect(parsleyInstance.__class__).to.be('ParsleyField');
       });
-      it('should return Parsley if instantiated on an unsupported element', function () {
+      it('should return ParsleyField even if instantiated on an unsupported element', function () {
         $('body').append('<div id="element"></div>');
         var parsleyInstance = new Parsley($('#element'));
         expect(parsleyInstance).to.be.an('object');
-        expect(parsleyInstance.__class__).to.be('Parsley');
+        expect(parsleyInstance.__class__).to.be('ParsleyField');
       });
-      it('should return Parsley instance if instantiated on an excluded field type, and do not have an errors container', function () {
+      it('should return ParsleyField instance even if instantiated on an excluded field type, and do not have an errors container', function () {
         $('body').append('<input type="submit" id="element" />');
         var parsleyInstance = new Parsley($('#element'));
         expect(parsleyInstance).to.be.an('object');
-        expect(parsleyInstance.__class__).to.be('Parsley');
-        expect($('#parsley-id-' + parsleyInstance.__id__).length).to.be(0);
+        expect(parsleyInstance.__class__).to.be('ParsleyField');
       });
       it('should have excluded fields by default', function () {
         $('body').append(
@@ -61,15 +60,18 @@ define(function () {
         expect(new Parsley($('#element')).OptionsFactory.staticOptions.namespace).to.be('data-parsley-');
 
         // global JS config
+        $('#element').parsley().destroy()
         window.ParsleyConfig.namespace = 'data-foo-';
         expect(new Parsley($('#element')).OptionsFactory.staticOptions.namespace).to.be('data-foo-');
 
         // option on the go
+        $('#element').parsley().destroy()
         expect(new Parsley($('#element'), {
           namespace: "data-bar-"
         }).OptionsFactory.staticOptions.namespace).to.be('data-bar-');
 
         // data- DOM-API
+        $('#element').parsley().destroy()
         $('#element').attr('data-parsley-namespace', 'data-baz-');
         expect(new Parsley($('#element'), {
           namespace: "data-bar-"

--- a/test/features/ui.js
+++ b/test/features/ui.js
@@ -8,10 +8,12 @@ define(function () {
         var UI = new ParsleyUI();
         expect(UI.listen).not.to.be(undefined);
       });
-      it('should create proper errors container', function () {
+      it('should create proper errors container when needed', function () {
         $('body').append('<input type="text" id="element" data-parsley-required />');
         var parsleyField = $('#element').psly();
         expect($('#element').attr('data-parsley-id')).to.be(parsleyField.__id__);
+        expect($('ul#parsley-id-' + parsleyField.__id__).length).to.be(0);
+        parsleyField.validate();
         expect($('ul#parsley-id-' + parsleyField.__id__).length).to.be(1);
         expect($('ul#parsley-id-' + parsleyField.__id__).hasClass('parsley-errors-list')).to.be(true);
       });
@@ -22,7 +24,7 @@ define(function () {
             '<div id="container"></div>'                                                             +
             '<div id="container2"></div>'                                                            +
           '</form>');
-        $('#element').psly();
+        $('#element').psly().validate();
         expect($('#container .parsley-errors-list').length).to.be(1);
         $('#element').psly().destroy();
         $('#field1').removeAttr('data-parsley-errors-container');
@@ -32,9 +34,9 @@ define(function () {
         expect($('#container2 .parsley-errors-list').length).to.be(1);
       });
       it('should handle wrong errors-container option', function () {
-        $('body').append('<input type="text" id="element" data-parsley-errors-container="#donotexist" />');
+        $('body').append('<input type="text" id="element" data-parsley-errors-container="#donotexist" required/>');
         window.console.warn = sinon.spy();
-        var parsleyInstance = $('#element').psly();
+        $('#element').psly().validate();
         expect(window.console.warn.called).to.be(true);
       });
       it('should add proper parsley class on success or failure (type=text)', function () {


### PR DESCRIPTION
TLDNR: This PR takes the approach that Parsley can’t and shouldn't filter fields at the constructor level and changes `init` to always return a `ParsleyForm` or `Parsley{Multiple}Field`, never a naked `Parsley`. It also adds error containers lazily (separate commit, could be split in a different PR).


Details:
In different circumstances, when calling `$.fn.parsley`, I get `Parsley` instances when I want `ParsleyField`.

I do not understand the idea behind return `Parsley` instances; it is definitely not useful for me, but maybe I'm missing something?

In any case, the current algorithm to decide to return a ParsleyField vs Parsley is deeply flawed. Ex:

    <form data-parlsey-excluded=“nothing”><input type=“hidden”></form>
    $(‘form').parsey()
    $(‘input’).parsley() # => Parsley, should be ParsleyField

This is because `Parsley#init` relies on incompletely formed options. Before a `ParsleyField` is created, the `OptionFactory` has no parent set, so won’t inherit the form’s `excluded`.

In any case, I believe that filtering at this stage is not the best approach.

For example, it seems natural to me to be able to add a constraint to a field even if it is currently in the excluded list, to account for the case where it might become included later. E.g:

    <form data-parlsey-excluded=“:hidden”><input type=“text" style=“display: none"></form>
    $(‘form').parsey()
    $(‘input’).parsley().addConstraint(…)
    $(‘.some-button’).click( function() { $(‘input’).show() } )

Currently, the way to achieve this is harder as it requires to subscribe to ‘parsley:form:init’ event and add the constraint at that point. This example is simple, but imagine more complex cases, where the visibility of an input depends on different code, loaded in an order that might change (and could suddenly break things if it hides the field before it’s bound).


In short, trying to decide if an element is a valid input or not in the constructor is tricky, brittle and 
best changed.

There was code to avoid creating a UI for excluded elements. I don’t think the condition was ever false, as parsley:field:init was never emitted for excluded elements.

I kept the code there in the first commit so that excluded fields don’t create UI unless it’s needed. This paves the way to a lazy adding of the error container. This avoids a some DOM pollution, in particular for fields that have no constraints… This last part could be separated in a different PR.
