### PR TITLE
Fix this.value override to allow empty string

### DIFF
--- a/src/parsley/field.js
+++ b/src/parsley/field.js
@@ -62,7 +62,8 @@ define('parsley/field', [
       if (0 === priorities.length)
         return this.validationResult = [];
       // Value could be passed as argument, needed to add more power to 'parsley:field:validate'
-      value = value || this.getValue();
+      if ('undefined' === typeof value || null === value)
+        value = this.getValue();
 
       // If a field is empty and not required, leave it alone, it's just fine
       // Except if `data-parsley-validate-if-empty` explicitely added, useful for some custom validators

--- a/test/features/field.js
+++ b/test/features/field.js
@@ -236,14 +236,14 @@ define(function () {
         expect($('#element').psly().isValid()).to.be.eql(false);
       });
       it('should allow `this.value` alteration with parsley:field:validate event', function () {
-        $('body').append('<input type="email" required id="element" />');
-        expect($('#element').parsley().validate()).not.to.be(true);
+        $('body').append('<input type="email" required id="element" value="foo@bar.baz" />');
+        expect($('#element').parsley().validate()).to.be(true);
 
         $('#element').parsley().subscribe('parsley:field:validate', function (fieldInstance) {
-          fieldInstance.value = 'foo@bar.baz';
+          fieldInstance.value = '';
         });
 
-        expect($('#element').parsley().validate()).to.be(true);
+        expect($('#element').parsley().validate()).not.to.be(true);
       });
       it('should have a force option for validate and isValid methods', function () {
         $('body').append('<input type="email" id="element" />');


### PR DESCRIPTION
The check for a given `value` was oversimplified and didn't allow for `''`.

I didn't use the shorter form `null == value` because that isn't used anywhere else, but would you consider using that check (there and elsewhere) when looking for `undefined` or `null`?

From [this SO question](http://stackoverflow.com/a/21273362/8279)
> Being a more experienced JS developer now, I should note that using `if (variable == null)` is in fact the standard way to catch null and undefined simultaneously. When writing professional JS, it's taken for granted that the behavior is understood.

Also: http://stackoverflow.com/a/15992131/8279