### PR TITLE
Value function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
   - jQuery events are now used instead of our pubsub code.
     The pubsub functions are now deprecated and will be removed in 3.0.0
+  - The `value` option can now be a function
 
 ## 2.0.6
 

--- a/doc/index.html
+++ b/doc/index.html
@@ -345,7 +345,15 @@
             <tbody>
               <tr>
                 <td><code>data-parsley-value</code> <version>#2.0</version></td>
-                <td>Set a specific field value for Parsley validation, dissociated from the real one. eg: <code>data-parsley-value="foo"</code></td>
+                <td>Set a specific field value for Parsley validation, dissociated from the real one. eg: <code>data-parsley-value="foo"</code>
+                  <br/>
+                The JavaScript API allows one to pass a function to be called. eg:
+                <code>
+                  $('&lt;input type="text"&gt;').appendTo($('form')).<br/>
+                  parsley({<br/>
+                  &nbsp;&nbsp;value: function(parsley) { return 'foo'; }<br/>
+                  });
+                </code></td>
               </tr>
               <tr>
                 <td><code>data-parsley-group</code> <version>#2.0</version></td>

--- a/src/parsley/field.js
+++ b/src/parsley/field.js
@@ -85,8 +85,10 @@ define('parsley/field', [
     getValue: function () {
       var value;
 
-      // Value could be overriden in DOM
-      if ('undefined' !== typeof this.options.value)
+      // Value could be overriden in DOM or with explicit options
+      if ('function' === typeof this.options.value)
+        value = this.options.value(this);
+      else if ('undefined' !== typeof this.options.value)
         value = this.options.value;
       else
         value = this.$element.val();

--- a/test/features/field.js
+++ b/test/features/field.js
@@ -262,6 +262,13 @@ define(function () {
         $('body').append('<input type="text" id="element"/>');
         expect($('#element').parsley({value: 'foo'}).getValue()).to.be('foo');
       });
+      it('should accept a function as value option', function () {
+        $('body').append('<input type="text" id="element"/>');
+        var str = 'fo';
+        var parsley = $('#element').parsley({value: function () { return str = str + 'o' } });
+        expect(parsley.getValue()).to.be('foo');
+        expect(parsley.getValue()).to.be('fooo');
+      });
       it('should properly handle null or undefined values', function () {
         $('body').append('<input type="text" id="element" required value/>');
         expect($('#element').parsley().isValid()).to.be(false);

--- a/test/features/field.js
+++ b/test/features/field.js
@@ -258,6 +258,10 @@ define(function () {
         $('#element').attr('data-parsley-trim-value', true).parsley().actualizeOptions();
         expect($('#element').parsley().getValue()).to.be('foo');
       });
+      it('should have a value option', function () {
+        $('body').append('<input type="text" id="element"/>');
+        expect($('#element').parsley({value: 'foo'}).getValue()).to.be('foo');
+      });
       it('should properly handle null or undefined values', function () {
         $('body').append('<input type="text" id="element" required value/>');
         expect($('#element').parsley().isValid()).to.be(false);


### PR DESCRIPTION
This PR allows `option.value` to be a function. This is not available with the `data-featherlight-value` API, of course, only using the JS api.

I realize that the same effect can be obtained by listening to the `validate` event and setting the field's `value` directly, but I feel that giving this other intuitive possibility is good.

Based on 2.1