### PR TITLE
Update parsley.css

### DIFF
--- a/src/parsley.css
+++ b/src/parsley.css
@@ -21,8 +21,6 @@ textarea.parsley-error {
   font-size: 0.9em;
   line-height: 0.9em;
   opacity: 0;
-  -moz-opacity: 0;
-  -webkit-opacity: 0;
 
   transition: all .3s ease-in;
   -o-transition: all .3s ease-in;


### PR DESCRIPTION
Remove unneeded vendor prefixes for opacity. The Moz-opacity was only ever needed for before Firefox 1.0 and I don't think webkit-opacity was ever used at all.
REF: http://css-tricks.com/css-transparency-settings-for-all-broswers/
REF: http://caniuse.com/#feat=css-opacity  (click show all - no vendor prefixes on record)