### PR TITLE
Re-register failing field trigger after reset() [#710]

### DIFF
--- a/src/parsley/ui.js
+++ b/src/parsley/ui.js
@@ -44,7 +44,7 @@ define('parsley/ui', [
       this.actualizeTriggers(fieldInstance);
 
       // If field is not valid for the first time, bind keyup trigger to ease UX and quickly inform user
-      if ((diff.kept.length || diff.added.length) && 'undefined' === typeof fieldInstance._ui.failedOnce)
+      if ((diff.kept.length || diff.added.length) && true !== fieldInstance._ui.failedOnce)
         this.manageFailingFieldTrigger(fieldInstance);
     },
 
@@ -374,6 +374,7 @@ define('parsley/ui', [
       parsleyInstance._ui.validatedOnce = false;
       parsleyInstance._ui.lastValidationResult = [];
       parsleyInstance._ui.validationInformationVisible = false;
+      parsleyInstance._ui.failedOnce = false;
     },
 
     destroy: function (parsleyInstance) {

--- a/test/features/ui.js
+++ b/test/features/ui.js
@@ -295,6 +295,31 @@ define(function () {
         parsleyInstance.reset();
         expect($('ul#parsley-id-' + parsleyInstance.__id__).hasClass('filled')).to.be(false);
       });
+      it('should re-bind error triggers after a reset (input=text)', function () {
+        $('body').append('<input type="text" id="element" required />');
+        var parsleyInstance = $('#element').parsley();
+        parsleyInstance.validate();
+        parsleyInstance.reset();
+        parsleyInstance.validate();
+        expect($('ul#parsley-id-' + parsleyInstance.__id__ + ' li').length).to.be(1);
+        $('#element').val('foo').trigger($.Event('keyup'));
+        expect($('ul#parsley-id-' + parsleyInstance.__id__ + ' li').length).to.be(0);
+      });
+      it('should re-bind error triggers after a reset (select)', function () {
+        $('body').append('<select id="element" required>'+
+          '<option value="">Choose</option>' +
+          '<option value="foo">foo</option>' +
+          '<option value="bar">bar</option>' +
+        '</select>');
+        var parsleyInstance = $('#element').parsley();
+        parsleyInstance.validate();
+        parsleyInstance.reset();
+        parsleyInstance.validate();
+        expect($('ul#parsley-id-' + parsleyInstance.__id__ + ' li').length).to.be(1);
+        $('#element option[value="foo"]').prop('selected', true);
+        $('#element').trigger($.Event('change'));
+        expect($('ul#parsley-id-' + parsleyInstance.__id__ + ' li').length).to.be(0);
+      });
       afterEach(function () {
         $('#element, .parsley-errors-list').remove();
       });


### PR DESCRIPTION
Fix issue where failing fields were not revalidated after resetting:
- Reset _ui.failedOnce to false in reset()
- Relax check in reflow() to allow undefined or false