### PR TITLE
Explicit overriding of an element's key by using a data attribute

### DIFF
--- a/src/extra/plugin/remote.js
+++ b/src/extra/plugin/remote.js
@@ -184,7 +184,7 @@ window.ParsleyExtend = $.extend(window.ParsleyExtend, {
       throw new Error('Calling an undefined async validator: `' + validator + '`');
 
     // Fill data with current value
-    data[this.$element.attr('name') || this.$element.attr('id')] = this.getValue();
+    data[this.$element.data('name') || this.$element.attr('name') || this.$element.attr('id')] = this.getValue();
 
     // Merge options passed in from the function with the ones in the attribute
     this.options.remoteOptions = $.extend(true, this.options.remoteOptions || {} , this.asyncValidators[validator].options);


### PR DESCRIPTION
There are situations where the name of an input (used for form submission) does not match that of the remote validation service.

For example, the local service accepting the form submission may expect the name `emailAddress`
A 3rd party validation service, such as postcode anywhere, is expecting an `Email` field

This addition allows you to either set the 3rd party field name before addAsyncValidator is called (using $.data), or by directly attaching a data-name attribute on the element
