### PR TITLE
Add an option to "squish" whitespace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 # Parsley 2.x changelog
 
 ## master
-
+  
+- added `data-parsley-squish-value` option
 - Support for validators with compound names by restoring ful case sensitivity
   to error messages. (#805)
 - new event 'form:submit.parsley' fired before a form is submitted.

--- a/doc/index.html
+++ b/doc/index.html
@@ -372,6 +372,10 @@
                 <td>Trim field value <strong>only for Parsley validation</strong> (and not inside the input itself, data sent by your form won't be trimmed). Useful if your backend already does so and if trailing spaces could unnecessarily mess with your validation. Use: <code>data-parsley-trim-value="true"</code>.</td>
               </tr>
               <tr>
+                <td><code>data-parsley-squish-value</code> <version>#2.1</version></td>
+                <td>Squish <em>(replace multiple sequential whitespace characters with a single whitespace character)</em> <strong>and</strong> trim field value <strong>only for Parsley validation</strong> (and not inside the input itself, data sent by your form won't be squished). Useful if your backend already does so and if multiple sequential whitespace characters could unnecessarily mess with your validation. Use: <code>data-parsley-squish-value="true"</code>.</td>
+              </tr>
+              <tr>
                 <td><code>data-parsley-ui-enabled</code> <version>#2.0</version></td>
                 <td>If set to <code>false</code>, Parsley will not affect UI for this field.</td>
               </tr>

--- a/src/parsley/field.js
+++ b/src/parsley/field.js
@@ -112,6 +112,10 @@ define('parsley/field', [
       if ('undefined' === typeof value || null === value)
         return '';
 
+      // Use `data-parsley-squish-value="true"` to auto squish inputs entry
+      if (true === this.options.squishValue)
+        return value.replace(/\s{2,}/g, ' ').replace(/^\s+|\s+$/g, '')
+
       // Use `data-parsley-trim-value="true"` to auto trim inputs entry
       if (true === this.options.trimValue)
         return value.replace(/^\s+|\s+$/g, '');

--- a/test/features/field.js
+++ b/test/features/field.js
@@ -259,6 +259,12 @@ define(function () {
         expect($('<input type="email" value="">').parsley().isValid(true)).to.be(false);
         expect($('<input type="email" value="foo">').parsley().isValid(true, "")).to.be(false);
       });
+      it('should have a squish-value option', function () {
+        $('body').append('<input type="text" id="element" value=" foo    bar " />');
+        expect($('#element').parsley().getValue()).to.be(' foo    bar ');
+        $('#element').attr('data-parsley-squish-value', true).parsley().actualizeOptions();
+        expect($('#element').parsley().getValue()).to.be('foo bar');
+      });
       it('should have a trim-value option', function () {
         $('body').append('<input type="text" id="element" value=" foo " />');
         expect($('#element').parsley().getValue()).to.be(' foo ');


### PR DESCRIPTION
The squish-value option squishes _all_ whitespace in the value, by
replacing multiple sequential whitespace characters with a single
space.
It also trims the value.

This can be useful when someone is attempting to get around min-length
validators by using strings like `a<multiple spaces>b`.

_Edit: Ironically I can't show a proper example here since GitHub squish 
the text in this field_