### PR TITLE
Add new whitespace API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## master
 
+- Deprecated `data-parsley-trim-value` in favour of new `whitespace` API
+- Added `whitespace` API with two options: `trim` and `squish`
+
 ## 2.1.2
 
 - fix custom triggers after a `reset()` (#926)

--- a/doc/index.html
+++ b/doc/index.html
@@ -412,8 +412,8 @@ if (false === instance.options.priorityEnabled)
                 <td>A field is by default not validated if it is not required and empty. By adding <code>data-parsley-validate-if-empty</code>, validation will be done even if field is empty. Useful if you need some custom validators that check something particular when a field is empty.</td>
               </tr>
               <tr>
-                <td><code>data-parsley-trim-value</code> <version>#2.0</version></td>
-                <td>Trim field value <strong>only for Parsley validation</strong> (and not inside the input itself, data sent by your form won't be trimmed). Useful if your backend already does so and if trailing spaces could unnecessarily mess with your validation. Use: <code>data-parsley-trim-value="true"</code>.</td>
+                <td><code>data-parsley-whitespace</code> <version>#2.1</version></td>
+                <td>Perform actions on whitespace in value <strong>only for Parsley validation</strong> (and not inside the input itself, data sent by your form won't be edited). Useful if your backend already does so and if extra whitespace could unnecessarily mess with your validation. <br><br>Use: <code>data-parsley-whitespace="trim"</code> to trim leading and trailing whitespace characters.<br>Use: <code>data-parsley-whitespace="squish"</code> to squish multiple sequential whitespace characters into a single whitespace character, and also trim leading and trailing whitespace characters.</td>
               </tr>
               <tr>
                 <td><code>data-parsley-ui-enabled</code> <version>#2.0</version></td>

--- a/src/parsley/field.js
+++ b/src/parsley/field.js
@@ -112,11 +112,7 @@ define('parsley/field', [
       if ('undefined' === typeof value || null === value)
         return '';
 
-      // Use `data-parsley-trim-value="true"` to auto trim inputs entry
-      if (true === this.options.trimValue)
-        return value.replace(/^\s+|\s+$/g, '');
-
-      return value;
+      return this._handleWhitespace(value);
     },
 
     // Actualize options that could have change since previous validation
@@ -263,6 +259,23 @@ define('parsley/field', [
     _trigger: function (eventName) {
       eventName = 'field:' + eventName;
       return this.trigger.apply(this, arguments);
+    },
+
+    // Internal only
+    // Handles whitespace in a value
+    // Use `data-parsley-whitespace="squish"` to auto squish input value
+    // Use `data-parsley-whitespace="trim"` to auto trim input value
+    _handleWhitespace: function (value) {
+      if (true === this.options.trimValue)
+        ParsleyUtils.warnOnce('data-parsley-trim-value="true" is deprecated, please use data-parsley-whitespace="trim"');
+
+      if ('squish' === this.options.whitespace)
+        value = value.replace(/\s{2,}/g, ' ');
+
+      if (('trim' === this.options.whitespace) || ('squish' === this.options.whitespace) || (true === this.options.trimValue))
+        value = value.replace(/^\s+|\s+$/g, '');
+
+      return value;
     },
 
     // Internal only.

--- a/test/features/field.js
+++ b/test/features/field.js
@@ -273,11 +273,25 @@ define(function () {
         expect($('<input type="email" value="">').parsley().isValid(true)).to.be(false);
         expect($('<input type="email" value="foo">').parsley().isValid(true, "")).to.be(false);
       });
+      it('should have a whitespace="squish" option', function () {
+        $('body').append('<input type="text" id="element" value=" foo    bar " />');
+        expect($('#element').parsley().getValue()).to.be(' foo    bar ');
+        $('#element').attr('data-parsley-whitespace', 'squish').parsley().actualizeOptions();
+        expect($('#element').parsley().getValue()).to.be('foo bar');
+      });
+      it('should have a whitespace="trim" option', function () {
+        $('body').append('<input type="text" id="element" value=" foo " />');
+        expect($('#element').parsley().getValue()).to.be(' foo ');
+        $('#element').attr('data-parsley-whitespace', 'trim').parsley().actualizeOptions();
+        expect($('#element').parsley().getValue()).to.be('foo');
+      });
       it('should have a trim-value option', function () {
         $('body').append('<input type="text" id="element" value=" foo " />');
         expect($('#element').parsley().getValue()).to.be(' foo ');
         $('#element').attr('data-parsley-trim-value', true).parsley().actualizeOptions();
-        expect($('#element').parsley().getValue()).to.be('foo');
+        expectWarning(function() {
+          expect($('#element').parsley().getValue()).to.be('foo');
+        });
       });
       it('should inherit options from the form, even if the form is bound after', function () {
         $('body').append('<form id="element" data-parsley-required>' +


### PR DESCRIPTION
The new `whitespace` API handles actions on whitespace, which at the
moment consist of `trim` and `squish`.
- `trim`: removes leading and trailing whitespace characters from the
value.
- `squish`: replaces multiple sequential whitespace characters with a
single space, and then performs a `trim`.

This API can be used by the following data attribute-value pairs:
`data-parsley-whitespace=“trim”` or `data-parsley-whitespace=“squish”`

This PR deprecates the use of `data-parsley-trim-value=“true”`.

This PR replaces #853.