### PR TITLE
Fixed a bug where specifying a minlength and maxlength of the same value...

### DIFF
--- a/src/parsley/field.js
+++ b/src/parsley/field.js
@@ -218,7 +218,7 @@ define('parsley/field', [
 
       // length
       if ('undefined' !== typeof this.$element.attr('minlength') && 'undefined' !== typeof this.$element.attr('maxlength'))
-        this.addConstraint('length', [this.$element.attr('minlength'), this.$element.attr('maxlength')], undefined, true);
+        this.addConstraint('length', [parseInt(this.$element.attr('minlength')), parseInt(this.$element.attr('maxlength'))], undefined, true);
 
       // HTML5 minlength
       else if ('undefined' !== typeof this.$element.attr('minlength'))

--- a/test/features/validator.js
+++ b/test/features/validator.js
@@ -129,6 +129,10 @@ define(function () {
         $('body').append('<input type="text" id="element" value="foo" data-parsley-maxlength="10" />');
         expect($('#element').parsley().isValid()).to.be(true);
       });
+      it('should handle maxlength and minlength with equal values', function () {
+        $('body').append('<input type="text" id="element" value="foo" minlength="3" maxlength="3" />');
+        expect($('#element').parsley().isValid()).to.be(true);
+      });
       it('should have a check validator', function () {
         expect(parsleyValidator.validate(['foo', 'bar', 'baz'], parsleyValidator.validators.check([3, 5]))).to.be(true);
         expect(parsleyValidator.validate(['foo', 'bar', 'baz', 'qux', 'bux'], parsleyValidator.validators.check([3, 4]))).not.to.be(true);


### PR DESCRIPTION
...did not work properly (only when use the HTML5 versions of those options).

Don't hesitate to ask if you'd prefer that I solve this in a different way.