### PR TITLE
Anchored pattern

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 2.2.0-rc2
 
 - Remote: use HTTP status code for what is considered valid or not (#956)
+- pattern validator is now anchored, unless it looks like /pattern/flag (#861)
 
 ## 2.2.0-rc1
 

--- a/doc/index.html
+++ b/doc/index.html
@@ -737,7 +737,10 @@ if (false === instance.options.priorityEnabled)
                     </tr>
                   </table>
                 </td>
-                <td>Validates that a value matches a specific regular expression (regex).</td>
+                <td>Validates that a value matches a specific regular expression (regex).
+                  <br/>Note that patterns are anchored, i.e. must match the whole string.
+                  <br/>Parsley deviates from the standard for patterns looking like <code>/<i>pattern</i>/<i>{flag}</i></code>; these are interpreted as litteral regexp and are not anchored.
+                </td>
               </tr>
               <tr>
                 <td>

--- a/src/parsley/validator.js
+++ b/src/parsley/validator.js
@@ -32,7 +32,7 @@ define('parsley/validator', [
       var flags = '';
 
       // Test if RegExp is literal, if not, nothing to be done, otherwise, we need to isolate flags and pattern
-      if (!!(/^\/.*\/(?:[gimy]*)$/.test(regexp))) {
+      if (/^\/.*\/(?:[gimy]*)$/.test(regexp)) {
         // Replace the regexp literal string with the first match group: ([gimy]*)
         // If no flag is present, this will be a blank string
         flags = regexp.replace(/.*\/([gimy]*)$/, '$1');

--- a/src/parsley/validator.js
+++ b/src/parsley/validator.js
@@ -1,5 +1,5 @@
 define('parsley/validator', [
-    'parsley/utils'
+  'parsley/utils'
 ], function (ParsleyUtils) {
 
   var requirementConverters = {
@@ -39,6 +39,9 @@ define('parsley/validator', [
         // Again, replace the regexp literal string with the first match group:
         // everything excluding the opening and closing slashes and the flags
         regexp = regexp.replace(new RegExp('^/(.*?)/' + flags + '$'), '$1');
+      } else {
+        // Anchor regexp:
+        regexp = '^' + regexp + '$';
       }
       return new RegExp(regexp, flags);
     }

--- a/test/features/validator_registry.js
+++ b/test/features/validator_registry.js
@@ -121,6 +121,14 @@ define(function () {
         expectValidation('a', 'pattern','/[a-z]+/i').to.be(true);
         expectValidation('A', 'pattern','/[a-z]+/i').to.be(true);
       });
+      it('should have a pattern validator that behaves as the standard when not of the form /pattern/flag', function () {
+        expectValidation('aa', 'pattern', '[a-z]{1,2}').to.be(true);
+        expectValidation('aaa', 'pattern', '[a-z]{1,2}').not.to.be(true);
+        expectValidation('aa',  'pattern', '^[a-z]{2}$').to.be(true);
+      });
+      it('should have a pattern validator that extends the standard for form /pattern/flag', function () {
+        expectValidation('zAz', 'pattern', '/a/i').to.be(true);
+      });
       it('should have a length validator', function () {
         expectValidation('foobar',    'length', [3, 9]).to.be(true);
         expectValidation('foo',       'length', [4, 9]).not.to.be(true);


### PR DESCRIPTION
We should anchor `<input pattern="foo">`, to be compatible with HTML5.
We can definitely accept `<input data-parsley-pattern="/foo/i">` as being unanchored.

The question is: what to do with `<input data-parsley-pattern="foo">` (anchored or not?) and `<input pattern="/foo/i">` (unanchored regex or anchored pattern starting with a slash?)

This PR suggests that `pattern` or `data-parsley-pattern` are dealt with the same way, so that patterns of the form `/<anything>/{flag}` are interpreted differently from HTML5 as litteral regex.
