### PR TITLE
Custom validator messages with compound names (via validator#addMessage)

### DIFF
--- a/src/parsley/validator.js
+++ b/src/parsley/validator.js
@@ -54,7 +54,7 @@ define('parsley/validator', [
       if ('undefined' === typeof this.catalog[locale])
         this.catalog[locale] = {};
 
-      this.catalog[locale][name.toLowerCase()] = message;
+      this.catalog[locale][name] = message;
 
       return this;
     },

--- a/test/features/ui.js
+++ b/test/features/ui.js
@@ -333,6 +333,33 @@ define(function () {
         window.ParsleyValidator.removeValidator('customValidator');
       });
 
+      it('should show configured error messages for custom validators with compound names', function () {
+        $('body').append('<input type="text" value="1" id="element" data-parsley-custom-validator="2" />');
+        window.ParsleyValidator.addValidator('customValidator', function (value, requirement) {
+          return requirement === value;
+        }, 32)
+          .addMessage('en','customValidator','Custom error message.')
+          .addMessage('fr','customValidator','Message d\'erreur personnalisé.');
+        var parsleyField = $('#element').psly();
+        parsleyField.validate();
+        expect($('ul#parsley-id-' + parsleyField.__id__ + ' li').text()).to.be('Custom error message.');
+        window.ParsleyValidator.removeValidator('customValidator');
+      });
+      it('should show configured error messages for custom validators with compound names in the current locale', function () {
+        $('body').append('<input type="text" value="1" id="element" data-parsley-custom-validator="2" />');
+        window.ParsleyValidator.addValidator('customValidator', function (value, requirement) {
+          return requirement === value;
+        }, 32)
+          .addMessage('en','Custom error message.')
+          .addMessage('fr',"Message d'erreur personnalisé.");
+        window.ParsleyValidator.setLocale('fr');
+        var parsleyField = $('#element').psly();
+        parsleyField.validate();
+        expect($('ul#parsley-id-' + parsleyField.__id__ + ' li').text()).to.be("Message d'erreur personnalisé.");
+        window.ParsleyValidator.setLocale('en');
+        window.ParsleyValidator.removeValidator('customValidator');
+      });
+
       afterEach(function () {
         $('#element, .parsley-errors-list').remove();
       });

--- a/test/features/ui.js
+++ b/test/features/ui.js
@@ -322,36 +322,41 @@ define(function () {
         expect($('ul#parsley-id-' + parsleyInstance.__id__ + ' li').length).to.be(0);
       });
 
-      it('should handle custom error message for validators with compound names', function () {
-        $('body').append('<input type="text" value="1" id="element" data-parsley-custom-validator="2" data-parsley-custom-validator-message="custom-validator error"/>');
-        window.ParsleyValidator.addValidator('customValidator', function (value, requirement) {
-          return requirement === value;
-        }, 32);
-        var parsleyField = $('#element').psly();
-        parsleyField.validate();
-        expect($('ul#parsley-id-' + parsleyField.__id__ + ' li').text()).to.be('custom-validator error');
-        window.ParsleyValidator.removeValidator('customValidator');
-      });
+      describe('Compound Names', function() {
+        beforeEach(function(done) {
+          window.ParsleyValidator.addValidator('customValidator', function (value, requirement) {
+            return requirement === value;
+          }, 32)
+            .addMessage('en','customValidator','Custom error message.')
+            .addMessage('fr','customValidator',"Message d'erreur personnalisé.");
+          done();
+        });
+        afterEach(function(done) {
+          window.ParsleyValidator.removeValidator('customValidator');
+          window.ParsleyValidator.setLocale('en');
+          $('#element').remove();
+          done();
+        });
+        it('should handle custom error message for validators with compound names', function () {
+          $('body').append('<input type="text" value="1" id="element" data-parsley-custom-validator="2" data-parsley-custom-validator-message="custom-validator error"/>');
+          var parsleyField = $('#element').psly();
+          parsleyField.validate();
+          expect($('ul#parsley-id-' + parsleyField.__id__ + ' li').text()).to.be('custom-validator error');
+        });
 
-      it('should show configured error messages for custom validators with compound names', function () {
-        $('body').append('<input type="text" value="1" id="element" data-parsley-custom-validator="2" />');
-        window.ParsleyValidator.addValidator('customValidator', function (value, requirement) {
-          return requirement === value;
-        }, 32)
-          .addMessage('en','customValidator','Custom error message.')
-          .addMessage('fr','customValidator','Message d\'erreur personnalisé.');
-        var parsleyField = $('#element').psly();
-        parsleyField.validate();
-        expect($('ul#parsley-id-' + parsleyField.__id__ + ' li').text()).to.be('Custom error message.');
-      });
-      it('should show configured error messages for custom validators with compound names in the current locale', function () {
-        $('body').append('<input type="text" value="1" id="element" data-parsley-custom-validator="2" />');
-        window.ParsleyValidator.setLocale('fr');
-        var parsleyField = $('#element').psly();
-        parsleyField.validate();
-        expect($('ul#parsley-id-' + parsleyField.__id__ + ' li').text()).to.be('Message d\'erreur personnalisé.');
-        window.ParsleyValidator.setLocale('en');
-        window.ParsleyValidator.removeValidator('customValidator');
+        it('should show configured error messages for custom validators with compound names', function () {
+          $('body').append('<input type="text" value="1" id="element" data-parsley-custom-validator="2" />');
+          var parsleyField = $('#element').psly();
+          parsleyField.validate();
+          expect($('ul#parsley-id-' + parsleyField.__id__ + ' li').text()).to.be('Custom error message.');
+        });
+        it('should show configured error messages for custom validators with compound names in the current locale', function () {
+          $('body').append('<input type="text" value="1" id="element" data-parsley-custom-validator="2" />');
+          window.ParsleyValidator.setLocale('fr');
+          var parsleyField = $('#element').psly();
+          parsleyField.validate();
+          expect($('ul#parsley-id-' + parsleyField.__id__ + ' li').text()).to.be("Message d'erreur personnalisé.");
+        });
       });
 
       afterEach(function () {

--- a/test/features/ui.js
+++ b/test/features/ui.js
@@ -343,19 +343,13 @@ define(function () {
         var parsleyField = $('#element').psly();
         parsleyField.validate();
         expect($('ul#parsley-id-' + parsleyField.__id__ + ' li').text()).to.be('Custom error message.');
-        window.ParsleyValidator.removeValidator('customValidator');
       });
       it('should show configured error messages for custom validators with compound names in the current locale', function () {
         $('body').append('<input type="text" value="1" id="element" data-parsley-custom-validator="2" />');
-        window.ParsleyValidator.addValidator('customValidator', function (value, requirement) {
-          return requirement === value;
-        }, 32)
-          .addMessage('en','Custom error message.')
-          .addMessage('fr',"Message d'erreur personnalisé.");
         window.ParsleyValidator.setLocale('fr');
         var parsleyField = $('#element').psly();
         parsleyField.validate();
-        expect($('ul#parsley-id-' + parsleyField.__id__ + ' li').text()).to.be("Message d'erreur personnalisé.");
+        expect($('ul#parsley-id-' + parsleyField.__id__ + ' li').text()).to.be('Message d\'erreur personnalisé.');
         window.ParsleyValidator.setLocale('en');
         window.ParsleyValidator.removeValidator('customValidator');
       });


### PR DESCRIPTION
Add tests for custom error messages without using data attributes (using validator#addMessage).

May be related to #806

The bug can be seen in this [jsfiddle](http://jsfiddle.net/alampros/dknc3nfk/).