### PR TITLE
added ability to change remote options on the fly

### DIFF
--- a/doc/index.html
+++ b/doc/index.html
@@ -1103,6 +1103,47 @@ $('[name="q"]').parsley()
           </ul>
         </p>
 
+        <h3 id="remote-events-list">Events List</h3>
+        <table class="table table-stripped table-bordered">
+          <thead>
+            <tr>
+              <th class="col-md-2">Name</th>
+              <th class="col-md-1">Arguments</th>
+              <th class="col-md-1">Fired by</th>
+              <th class="col-md-4">Description</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td><code>field:validate.parsley</code> <version>#2.1</version></td>
+              <td><code>event</code>, <code>ParsleyField</code>, <code>xhrOptions</code></td>
+              <td><code>.asyncIsValid()</code></td>
+              <td>
+                Trigger <strong>after</strong> the raw XmlHttpRequest options are built, <strong>before</strong> the actual call to <strong>$.ajax()</strong>.
+                For further information about available options and setting see <a href="http://api.jquery.com/jquery.ajax/#jQuery-ajax-settings">$.ajax()</a>.
+              </td>
+            </tr>
+          </tbody>
+        </table>
+
+        <h3 id="remote-events-usage">Events Usage</h3>
+        <p>Configuring the listener is really straight forward:
+<pre><code>&lt;input id="q" name="q" type="text" data-parsley-remote data-parsley-remote-validator='mycustom' value="foo" />
+[...]
+&lt;script href="parsley.remote.js">&lt;/script>
+&lt;script href="parsley.js">&lt;/script>
+&lt;script type="text/javascript">
+$("#q").on('field:ajaxOptions.parsley', function (evt, field, xhrOptions) {
+  xhrOptions.url = 'http://new.url';
+  if (!('data' in xhrOptions)) {
+    xhrOptions.data = {};
+  }
+  xhrOptions.data['new-parameter'] = 'new-value';
+});
+&lt;/script>
+</code></pre>
+        </p>
+
         <!-- ****************** Extra ****************** -->
         <h1 id="extras" class="page-header">Parsley Extras</h1>
         <p>
@@ -1300,6 +1341,10 @@ $('[name="q"]').parsley()
               </li>
               <li>
                 <a href="#remote">Parsley Remote</a>
+                <ul class="nav">
+                    <li><a href="#remote-events-list">Events</a></li>
+                    <li><a href="#remote-events-usage">Usage</a></li>
+                </ul>
               </li>
               <li>
                 <a href="#extras">Parsley Extras</a>

--- a/src/extra/plugin/remote.js
+++ b/src/extra/plugin/remote.js
@@ -198,6 +198,9 @@ window.ParsleyExtend = $.extend(window.ParsleyExtend, {
       type: 'GET'
     }, this.options.remoteOptions || {});
 
+    // Emit an event to allow sending aditional data or modify the options dynamically
+    this.$element.trigger('field:ajaxOptions.parsley', [this, ajaxOptions]);
+
     // Generate store key based on ajax options
     csr = $.param(ajaxOptions);
 

--- a/test/features/remote.js
+++ b/test/features/remote.js
@@ -225,6 +225,25 @@ define('features/remote', [
         expect(parsleyInstance._remoteCache.dummy).to.be(undefined);
       });
 
+      it('should allow the change of XHR url', function (done) {
+        $('body').append('<input type="text" data-parsley-remote id="element" data-parsley-remote-validator="mycustom" required name="element" value="foobar" />');
+        var form = $('#element'),
+          parsleyInstance = form.parsley(),
+          cb = function (e, field, options) {
+            options.url = 'http://debian.com';
+          };
+        form.on('field:ajaxOptions.parsley', cb);
+
+        sinon.stub($, 'ajax').returns($.Deferred().resolve({}, 'success', { status: 200, state: function () { return 'resolved' } }));
+        parsleyInstance.asyncIsValid()
+          .fail(function () {
+            expect($.ajax.calledWithMatch({ url: "http://debian.com" })).to.be(true);
+            $.ajax.restore();
+            form.off('field:ajaxOptions.parsley');
+            done();
+          });
+      });
+
       it.skip('should abort successives querries and do not handle their return');
       afterEach(function () {
         $('#element, .parsley-errors-list').remove();


### PR DESCRIPTION
When trying to validated a field together with an adjacent field, the `parsley:field:validate` is simply not powerful enough to allow you to send additional data dynamically and neither is the `data-parsley-remote-options` attribute.

This applies, for example, when remotely validating international phone numbers which require the user to also select the country in order to apply formatting rules.

```javascript
// this fails and data is never sent
$.listen('parsley:field:validate', function (field) {
  if (field === someRefToMyField) {
    field.options.remoteOptions.data = {someName: $someField.val()};
  }
});
// this works
$.listen('parsley:remote:options', function (field, options) {
  if (field === someRefToMyField) {
    options.data = {someName: $someField.val()};
  }
});
```