### PR TITLE
Asyncmethod

### DIFF
--- a/src/extra/plugin/remote.js
+++ b/src/extra/plugin/remote.js
@@ -22,9 +22,13 @@ window.ParsleyExtend = $.extend(window.ParsleyExtend, {
       url: false
     },
     reverse: {
+      fntype:'xhr',
       fn: function (xhr) {
         // If reverse option is set, a failing ajax request is considered successful
         return 'rejected' === xhr.state();
+      },
+      asyncmethod: function(value, callbackboolean){
+    	  callbackboolean(true);
       },
       url: false
     }
@@ -40,13 +44,13 @@ window.ParsleyExtend = $.extend(window.ParsleyExtend, {
     return this;
   },
 	  
-  addAsyncMethodValidator: function (name, fn, url, options) {
+  addAsyncMethodValidator: function (name, fn) {
     this.asyncValidators[name.toLowerCase()] = {
       fn: fn,
       fntype:'method',
       asyncmethod: fn,
-      url: url || false,
-      options: options || {}
+      url: false,
+      options: {}
     };
 
     return this;
@@ -204,7 +208,7 @@ window.ParsleyExtend = $.extend(window.ParsleyExtend, {
     // Fill data with current value
     data[this.$element.attr('name') || this.$element.attr('id')] = this.getValue();
 
-    if (this.asyncValidators[validator].fntype=='xhr') {
+    if (!this.asyncValidators[validator].fntype || this.asyncValidators[validator].fntype=='xhr') {
 	    // Merge options passed in from the function with the ones in the attribute
 	    this.options.remoteOptions = $.extend(true, this.options.remoteOptions || {} , this.asyncValidators[validator].options);
 	
@@ -246,8 +250,7 @@ window.ParsleyExtend = $.extend(window.ParsleyExtend, {
 	
 	        that._handleRemoteResult(validator, xhr, deferred);
 	      });
-    }
-    if (this.asyncValidators[validator].fntype=='method') {
+    } else if ('method'===this.asyncValidators[validator].fntype) {
     	that.$element.addClass('parsley-pending');
     	this.asyncValidators[validator].asyncmethod(this.getValue(), function(booleanresult) {
     		that.$element.removeClass('parsley-pending');

--- a/test/dev.html
+++ b/test/dev.html
@@ -2,9 +2,11 @@
 <head>
     <meta charset="utf-8">
     <title>Parsleyjs Developpement Tests</title>
-    <link href="../src/parsley.css" rel="stylesheet">
+<!--     <link href="../src/parsley.css" rel="stylesheet"> -->
     <style type="text/css">
-
+input.parsley-pending {
+  background-color: red;
+}
     </style>
 </head>
 <body>
@@ -55,10 +57,14 @@
         <input type="submit">
     </form> -->
 
-    <form id="parsley" data-parsley-validate>
-        <input type="checkbox" name="check[]" required data-parsley-check="[3, 5]" value="0">
-        <input type="checkbox" name="check[]" value="1">
+    <form id="parsley" data-parsley-validate> 
 
+		<p>
+		<input type="text" name="remotemethod" value="z"
+			data-parsley-error-message="type x please"
+			data-parsley-remote
+			data-parsley-remote-validator='mycustom'>
+		</p>
         <br/>
 
         <div id="add">Add</div>
@@ -83,7 +89,7 @@
     </form> -->
 
     <script src="../bower_components/jquery/dist/jquery.js"></script>
-    <!-- <script src="../src/parsley.remote.js"></script> -->
+<!--     <script src="../src/parsley.remote.js"></script> -->
     <!-- <script src="../src/extra/dateiso.js"></script> -->
     <!-- <script src="../src/i18n/fr.extra.js"></script> -->
     <!-- <script src="../src/i18n/fr.js"></script> -->
@@ -106,6 +112,7 @@
         // };
     </script>
 
+    <script src="../src/extra/plugin/remote.js"></script>
     <script src="../dist/parsley.js"></script>
     <!-- <script src="../bower_components/requirejs/require.js" data-main="./dev"></script></body> -->
     <!-- <script src="../bower_components/requirejs/require.js" data-main="../src/main"></script></body> -->
@@ -124,5 +131,23 @@
         //         $('[type=checkbox]:last').remove();
         //     });
         // });
+        $(document).ready(function () {
+        	var parsley = $('INPUT[name="remotemethod"]').parsley();
+        	parsley.addAsyncMethodValidator('mycustom', function(value, callbackboolean) {
+        		window.ParsleyUI.removeError(parsley, "mycustom");
+	        	window.setTimeout(function() {
+	        			console.log('remote ='+value);
+	        			var res = value=='x';
+	            		if (!res) {
+	            			window.ParsleyUI.addError(parsley, "mycustom", 'custom message'+value);
+	            		}
+	        			callbackboolean(res);
+	        	}, 1000);
+	        });
+// 	        $('INPUT[name="remotemethod"]').parsley().addAsyncValidator('mycustom', function(xhr) {
+// 	        	console.log('remote');
+// 	        	return false;
+// 	        }, 'http://aaa.com/xxx');
+        	});
     </script>
 </html>


### PR DESCRIPTION
Hello,

We have multiple issues regarding asyncMethod : 
- We want to use more than one async validator per field
- We want different messages for each validator
- We need to make the XHR call ourself (because we rely on a layer to do that).

The current implementation of async if too much based on jquery XHR and we propose to add a new async validator type.
The current one is the "xhr" type because it's base on XHR and we added a "method" one.
The goal of this validator is to provide only a method with a callback.
The method to async stuff and calls the callback with a boolean to say if it's success or not.

To use it, one has just to add a "addAsyncMethod".
I've modified the dev.html file for having a clear example of how to use it. I don't think it has to be merged.

I can provide tests and docs if you plan to merge it.

Pascal / La Roue Verte.

Issues related : 
https://github.com/guillaumepotier/Parsley.js/issues/905