### PR TITLE
Re-bind custom triggers during a reset

### DIFF
--- a/src/parsley/ui.js
+++ b/src/parsley/ui.js
@@ -353,7 +353,7 @@ define('parsley/ui', [
 
     reset: function (parsleyInstance) {
       // Reset all event listeners
-      parsleyInstance.$element.off('.Parsley');
+      this.actualizeTriggers(parsleyInstance);
       parsleyInstance.$element.off('.ParsleyFailedOnce');
 
       // Nothing to do if UI never initialized for this field

--- a/test/features/ui.js
+++ b/test/features/ui.js
@@ -321,7 +321,14 @@ define(function () {
         $('#element').trigger($.Event('change'));
         expect($('ul#parsley-id-' + parsleyInstance.__id__ + ' li').length).to.be(0);
       });
-
+      it('should re-bind custom triggers after a reset', function () {
+        $('body').append('<input type="text" id="element" required data-parsley-trigger="focusout" />');
+        var parsleyInstance = $('#element').parsley();
+        parsleyInstance.validate();
+        parsleyInstance.reset();
+        $('#element').focus().blur();
+        expect($('ul#parsley-id-' + parsleyInstance.__id__ + ' li').length).to.be(1);
+      });
       it('should handle custom error message for validators with compound names', function () {
         $('body').append('<input type="text" value="1" id="element" data-parsley-custom-validator="2" data-parsley-custom-validator-message="custom-validator error"/>');
         window.ParsleyValidator.addValidator('customValidator', function (value, requirement) {


### PR DESCRIPTION
This is related to #843 which deals with the automatic change trigger but does not address the fact that when you call reset() any custom bindings added from the data-parsley-trigger attribute are lost.