### PR TITLE
Make AMD module in minified file return Parsley 

### DIFF
--- a/src/wrap/append.js
+++ b/src/wrap/append.js
@@ -1,1 +1,2 @@
+	return window.Parsley;
 }));


### PR DESCRIPTION
That way it's passed to the define callback function of dependant modules as expected.
Fixes https://github.com/guillaumepotier/Parsley.js/issues/930