### PR TITLE
Fix typo fist to first.

### DIFF
--- a/dist/parsley.js
+++ b/dist/parsley.js
@@ -143,7 +143,7 @@
     uiEnabled: true,
     // Key events threshold before validation
     validationThreshold: 3,
-    // Focused field on form validation error. 'fist'|'last'|'none'
+    // Focused field on form validation error. 'first'|'last'|'none'
     focus: 'first',
     // `$.Event()` that will trigger validation. eg: `keyup`, `change`...
     trigger: false,

--- a/dist/parsley.remote.js
+++ b/dist/parsley.remote.js
@@ -415,7 +415,7 @@ window.Parsley.on('form:submit', function () {
     uiEnabled: true,
     // Key events threshold before validation
     validationThreshold: 3,
-    // Focused field on form validation error. 'fist'|'last'|'none'
+    // Focused field on form validation error. 'first'|'last'|'none'
     focus: 'first',
     // `$.Event()` that will trigger validation. eg: `keyup`, `change`...
     trigger: false,

--- a/src/parsley/defaults.js
+++ b/src/parsley/defaults.js
@@ -34,7 +34,7 @@ define('parsley/defaults', function () {
     // Key events threshold before validation
     validationThreshold: 3,
 
-    // Focused field on form validation error. 'fist'|'last'|'none'
+    // Focused field on form validation error. 'first'|'last'|'none'
     focus: 'first',
 
     // `$.Event()` that will trigger validation. eg: `keyup`, `change`...


### PR DESCRIPTION
Was reading through the docs and noticed this. Assuming it should be `first` and not `fist`.