### PR TITLE
Promise

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## master
 
+- Major validators refactor:
+  - Compatible with promises from the ground up. Previous API (e.g. `isValid`)
+    remains, but promise-aware API is now recommended (e.g. `whenValid`).
+  - New API to define custom validators (old API is still there but deprecated).
+  - Shorter code, removed dependency on `validators` lib.
+  - The `remote` validator is much smaller now, will probably be merged in the future.
+
 - Deprecated `data-parsley-trim-value` in favour of new `whitespace` API
 - Added `whitespace` API with two options: `trim` and `squish`
 

--- a/doc/index.html
+++ b/doc/index.html
@@ -168,12 +168,12 @@
 &lt;script src="i18n/it.js">&lt;/script>
 &lt;script src="parsley.min.js">&lt;/script>
 &lt;script type="text/javascript">
-  window.ParsleyValidator.setLocale('fr');
+  window.Parsley.setLocale('fr');
 &lt;/script>
 </code></pre>
               </li>
               <li>
-                Load your needed localization <strong>after</strong> Parsley. The last loaded file will automatically set the messages locale for ParsleyValidator. In this example, we'll load both French and Italian translations, and use Italian:
+                Load your needed localization <strong>after</strong> Parsley. The last loaded file will automatically set the messages locale for Parsley. In this example, we'll load both French and Italian translations, and use Italian:
 <pre><code>&lt;script src="jquery.js">&lt;/script>
 &lt;script src="parsley.min.js">&lt;/script>
 &lt;script src="i18n/fr.js">&lt;/script>
@@ -776,7 +776,7 @@ if (false === instance.options.priorityEnabled)
 <pre><code>&lt;input type="text" data-parsley-multipleof="3" />
 [...]
 &lt;script type="text/javascript">
-window.Parsley.Validators
+window.Parsley
   .addValidator('multipleof', {
     requirementType: 'integer',
     validateNumber: function(value, requirement) {

--- a/doc/index.html
+++ b/doc/index.html
@@ -781,10 +781,12 @@ window.Parsley
     requirementType: 'integer',
     validateNumber: function(value, requirement) {
       return 0 === value % requirement;
+    },
+    messages: {
+      en: 'This value should be a multiple of %s',
+      fr: 'Cette valeur doit être un multiple de %s'
     }
-  )
-  .addMessage('en', 'multipleof', 'This value should be a multiple of %s')
-  .addMessage('fr', 'multipleof', 'Cette valeur doit être un multiple de %s');
+  );
 &lt;/script>
 </code></pre>
           </p>
@@ -857,6 +859,10 @@ window.Parsley
 
           <p>For even cases where more complex parameters are needed, you can specify extra parameters; refer to the source and check how the <code>remote</code> validator uses that.</p>
         </div>
+
+          <h3 id="custom-messages">Error messages</h3>
+          <p>You can specify error messages, in as many locales as desired, using the <code>messages</code> option.</p>
+          <p>This is equivalent to calling <code>addMessage</code> for each locale.</p>
 
         <!-- ****************** UI/ UX ****************** -->
         <h1 id="ui" class="page-header">UI/UX</h1>
@@ -1372,6 +1378,7 @@ $('[name="q"]').parsley()
                   <li><a href="#custom-intro">Craft yours!</a></li>
                   <li><a href="#custom-function">Validating functions</a></li>
                   <li><a href="#custom-requirement">Requirement parameters</a></li>
+                  <li><a href="#custom-messages">Error messages</a></li>
                 </ul>
               </li>
               <li>

--- a/doc/index.html
+++ b/doc/index.html
@@ -486,15 +486,13 @@ if (false === instance.options.priorityEnabled)
           <h1 id="validators" class="page-header">Built-in validators</h1>
           <h3 id="validators-overview">Overview</h3>
           <p>
-            Parsley 2.x is now based on <a href="http://validatorjs.org">validator.js</a> that ships commonly used validators and simplifies group and priority validation. That way, Parsley can share validators with validator.js and define new ones using the <code>Callback()</code> Assert.
+            A <i>validator</i> is a method to determine if a given <i>value</i> (or sometimes sets of values) is acceptable or not, given some <i>requirement</i> parameters.
+          </p>
+          <p>
+            Parsley comes with many builtin validators and provides tools to specify your own.
           </p>
 
-          <div class="bs-callout bs-callout-info">
-            <h4>Use Validator.js in your Parsley projects</h4>
-            <p>Parsley lets you use validator.js in <code>window.ParsleyValidator.Validator</code></p>
-          </div>
-
-          <h3 id="validators-list">Validators list</h3>
+          <h3 id="validators-list">Builtin validators list</h3>
           <table class="table table-stripped table-bordered">
             <thead>
               <tr>
@@ -769,51 +767,95 @@ if (false === instance.options.priorityEnabled)
             These validators are shipped in <code>parsley.js</code>. Have a look at the <a href="#remote">Parsley Remote</a> plugin and <a href="#extras">Parsley Extras</a> for more validators.
           </p>
 
-          <h3 id="validators-craft">Craft yours!</h3>
+          <h1 id="custom">Custom Validators</h3>
+          <h3 id="custom-intro">Craft yours</h3>
           <p>Of course, Parsley built-in validators are commonly used validators, and you'll need some more that fit your specific forms and validations. That's why Parsley lets you easily create your own validators.</p>
           <p>
-          <p>Here again, like localizations, configuring your custom validators and error messages comes in two flavors:
-          <ul>
-            <li>By registering them in globals <strong>before</strong> loading <code>parsley.js</code>:
-<pre><code>&lt;input type="text" data-parsley-multipleof="3" />
-[...]
-&lt;script type="text/javascript">
-window.ParsleyConfig = {
-  validators: {
-    multipleof: {
-      fn: function (value, requirement) {
-        return 0 === value % requirement;
-      },
-      priority: 32
-    }
-  },
-  i18n: {
-    en: {
-      multipleof: 'This value should be a multiple of %s'
-    },
-    fr: {
-      multipleof: 'Cette valeur doit être un multiple de %s'
-    }
-  }
-};
-&lt;/script>
-</code></pre>
-            </li>
-            <li>By registering them in <code>ParsleyValidator</code> <strong>after</strong> <code>parsley.js</code> is loaded:
+          <p>The preferred way to register them (after <code>parsley.js</code> is loaded) looks like:
 
 <pre><code>&lt;input type="text" data-parsley-multipleof="3" />
 [...]
 &lt;script type="text/javascript">
-window.ParsleyValidator
-  .addValidator('multipleof', function (value, requirement) {
-    return 0 === value % requirement;
-  }, 32)
+window.Parsley.Validators
+  .addValidator('multipleof', {
+    requirementType: 'integer',
+    validateNumber: function(value, requirement) {
+      return 0 === value % requirement;
+    }
+  )
   .addMessage('en', 'multipleof', 'This value should be a multiple of %s')
   .addMessage('fr', 'multipleof', 'Cette valeur doit être un multiple de %s');
 &lt;/script>
-</code></pre></li>
-          </ul>
+</code></pre>
           </p>
+          <p>The following sections go over the details on how to define a custom validator</p>
+          <h3 id="custom-function">Validating function</h3>
+          <p>There are many ways a validator can specify how to validate data:
+          <table class="table table-stripped table-bordered">
+            <thead>
+              <tr>
+                <th class="col-md-1">Name</th>
+                <th class="col-md-4">Description</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td><code>validateString</code></td>
+                <td>Is passed the input's value as a string.</td>
+              </tr>
+              <tr>
+                <td><code>validateNumber</code></td>
+                <td>Use this instead of <code>validateString</code> when only numeric values are acceptable. Parsley will parse the input's value and pass the number, or reject the value if it's not an acceptable number</td>
+              </tr>
+              <tr>
+                <td><code>validateMultiple</code></td>
+                <td>Is passed an array of values, in the case of checkboxes.</td>
+              </tr>
+            </tbody>
+          </table>
+
+          <p>Your custom validator must specify at least one of these. If it can validate both single inputs and multiple (i.e. checkboxes), then you can specify <i>validateMultiple</i> and one of the other two.</p>
+
+          <p>Validating functions should return either <code>true</code> if the value is valid, or <code>false</code> otherwise. It can instead return a promise that will be resolved if the value is valid, or be rejected otherwise.</p>
+
+          <h3 id="custom-requirement">Requirement parameters</h3>
+
+          <p>You can specify what kind of requirement parameter your custom validator is expecting:
+          <table class="table table-stripped table-bordered">
+            <thead>
+              <tr>
+                <th class="col-md-1"><code>requirementKind</code></th>
+                <th class="col-md-4">Description</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td><code>string</code></td>
+                <td>The most generic kind; requirement passed as is, with no checking.</td>
+              </tr>
+              <tr>
+                <td><code>integer</code></td>
+                <td>For integers only (e.g. used by <code>minlength</code>)</td>
+              </tr>
+              <tr>
+                <td><code>number</code></td>
+                <td>To be used when decimal numbers are acceptable</td>
+              </tr>
+              <tr>
+                <td><code>regexp</code></td>
+                <td>Requirement can be either a full regexp string (e.g. <code>/hel+o/i</code>) or just a simple expression (e.g. <code>hel+o</code>)</td>
+              </tr>
+              <tr>
+                <td><code>boolean</code></td>
+                <td>Any value other than <code>"false"</code> will be considered to <code>true</code>, including the empty string. This is so <code>data-parsley-required</code> and <code>data-parsley-required=true</code> be treated the same way.</td>
+              </tr>
+            </tbody>
+          </table>
+
+          <p>You can also specify an array of these kinds. For example, if a validator has <code>requirementKind: ['integer', 'integer']</code>, then given the requirement string <code>"[1, 2]"</code> it will receive <code>1</code> and <code>2</code> as second and third arguments (the first one being the value(s) to validate).
+          </p>
+
+          <p>For even cases where more complex parameters are needed, you can specify extra parameters; refer to the source and check how the <code>remote</code> validator uses that.</p>
         </div>
 
         <!-- ****************** UI/ UX ****************** -->
@@ -1321,8 +1363,15 @@ $('[name="q"]').parsley()
                 <a href="#validators">Built-in validators</a>
                 <ul class="nav">
                   <li><a href="#validators-overview">Overview</a></li>
-                  <li><a href="#validators-list">Validators list</a></li>
-                  <li><a href="#validators-craft">Craft yours!</a></li>
+                  <li><a href="#validators-list">Built-in validators list</a></li>
+                </ul>
+              </li>
+              <li>
+                <a href="#custom">Custom validators</a>
+                <ul class="nav">
+                  <li><a href="#custom-intro">Craft yours!</a></li>
+                  <li><a href="#custom-function">Validating functions</a></li>
+                  <li><a href="#custom-requirement">Requirement parameters</a></li>
                 </ul>
               </li>
               <li>

--- a/doc/index.html
+++ b/doc/index.html
@@ -346,16 +346,28 @@ if (false === instance.options.priorityEnabled)
             </thead>
             <tbody>
               <tr>
+                <td><code>whenValid(group, force)</code> <version>#2.2</version></td>
+                <td><code>promise</code></td>
+                <td>Returns a promise that will be fulfilled if and only if the Form is valid. <strong>Does not affect UI nor fires <a href="#events">events</a>.</strong> If <code>group</code> is given, it only validates fields that belong to this group. If <code>force</code> is given, it force validates even non-required fields (<a href="examples/events.html">See example</a>)</td>
+              </tr>
+              <tr>
                 <td><code>isValid(group, force)</code> <version>#2.0</version></td>
-                <td><code>boolean</code></td>
-                <td>Returns if the Form is valid or not. <strong>Does not affect UI nor fires <a href="#events">events</a>.</strong> If <code>group</code> is given, it only validates fields that belong to this group. If <code>force</code> is given, it force validates even non-required fields (<a href="examples/events.html">See example</a>)</td>
+                <td><code>boolean or null</code></td>
+                <td>Similar to <code>whenValid</code> but returns <code>true</code> if the promise is already fulfilled, <code>false</code> if already rejected, and <code>null</code> if the validation is still pending.</td>
+              </tr>
+              <tr>
+                <td><code>whenValidate(group, force)</code> <version>#2.0</version></td>
+                <td>
+                  <code>promise</code>
+                </td>
+                <td>Validate form. Prevents submission if not valid. <strong>Fires <a href="#events">events</a> and affects UI.</strong>. You can only validate a certain group of fields by specifying optional <code>group</code> string parameter. If <code>group</code> is given, it only validates fields that belong to this group. If <code>force</code> is given, it force validates even non required fields (<a href="examples/events.html">See example</a>). Same result as <code>whenValid</code>.</td>
               </tr>
               <tr>
                 <td><code>validate(group, force)</code> <version>#2.0</version></td>
                 <td>
-                  <code>boolean</code>
+                  <code>boolean or null</code>
                 </td>
-                <td>Validate form. Prevents submission if not valid. <strong>Fires <a href="#events">events</a> and affects UI.</strong>. You can only validate a certain group of fields by specifying optional <code>group</code> string parameter. If <code>group</code> is given, it only validates fields that belong to this group. If <code>force</code> is given, it force validates even non required fields (<a href="examples/events.html">See example</a>)</td>
+                <td>Same as <code>whenValidate</code> except it returns <code>true</code> if the promise is already fulfilled, <code>false</code> if already rejected, and <code>null</code> if the validation is still pending.</td>
               </tr>
               <tr>
                 <td><code>reset()</code> <version>#2.0</version></td>
@@ -1139,53 +1151,21 @@ window.Parsley
           </thead>
           <tbody>
             <tr>
-              <td><code>asyncIsValid()</code> <version>#2.0</version></td>
-              <td>Asynchronously get if field or form is valid or not. Returns a jQuery promise.</td>
-            </tr>
-            <tr>
-              <td><code>asyncValidate()</code> <version>#2.0</version></td>
-              <td>Asynchronously validate a field or a form and display UI errors. Returns a jQuery promise.</td>
-            </tr>
-            <tr>
-              <td><code>addAsyncValidator(name, fn)</code> <version>#2.0</version></td>
-              <td>Add a new custom remote validator.</td>
+              <td><code>Parsley.addAsyncValidator(name, fn)</code> <version>#2.0</version></td>
+              <td>Specify custom validator for Ajax results.</td>
             </tr>
           </tbody>
         </table>
 
         <a name="remote-custom"></a>
         <h3>Custom remote validators</h3>
-        <p>Configuring your custom remote validators comes with two solutions:
-          <ul>
-            <li>By registering them in some globals <strong>before</strong> calling <code>parsley.remote.js</code>:
-<pre><code>&lt;input name="q" type="text" data-parsley-remote data-parsley-remote-validator='mycustom' value="foo" />
-[...]
-&lt;script type="text/javascript">
-window.ParsleyExtend = {
-  asyncValidators: {
-    mycustom: {
-      fn: function (xhr) {
-        console.log(this.$element); // jQuery Object[ input[name="q"] ]
-
-        return 404 === xhr.status;
-      },
-      url: 'http://mycustomapiurl.ext'
-    }
-  }
-};
-&lt;/script>
-&lt;script href="parsley.remote.js">&lt;/script>
-&lt;script href="parsley.js">&lt;/script>
-</code></pre>
-            </li>
-            <li>By registering them <strong>after</strong> <code>parsley.remote.js</code> is loaded:
+        <p>If you need some custom processing of Ajax responses, configure your custom remote as follows:
 <pre><code>&lt;input name="q" type="text" data-parsley-remote data-parsley-remote-validator='mycustom' value="foo" />
 [...]
 &lt;script href="parsley.remote.js">&lt;/script>
 &lt;script href="parsley.js">&lt;/script>
 &lt;script type="text/javascript">
-$('[name="q"]').parsley()
-  .addAsyncValidator('mycustom', function (xhr) {
+window.Parsley.addAsyncValidator('mycustom', function (xhr) {
     console.log(this.$element); // jQuery Object[ input[name="q"] ]
 
     return 404 === xhr.status;

--- a/src/extra/plugin/remote.js
+++ b/src/extra/plugin/remote.js
@@ -98,4 +98,9 @@ window.Parsley.on('form:submit', function () {
   window.Parsley._remoteCache = {};
 });
 
+window.ParsleyExtend.addAsyncValidator = function () {
+  window.ParsleyUtils.warnOnce('Accessing the method `addAsyncValidator` through an instance is deprecated. Simply call `window.Parsley.addAsyncValidator(...)`');
+  return window.Parsley.apply(window.Parsley.addAsyncValidator, arguments);
+};
+
 })(jQuery);

--- a/src/extra/plugin/remote.js
+++ b/src/extra/plugin/remote.js
@@ -241,11 +241,7 @@ window.ParsleyExtend = $.extend(true, window.ParsleyExtend, {
 
     // Else, create a proper remote validation Violation to trigger right UI
     this.validationResult = [
-      new window.ParsleyValidator.Validator.Violation(
-        this.constraintsByName.remote,
-        this.getValue(),
-        null
-      )
+      {assert: this.constraintsByName.remote}
     ];
 
     deferred.rejectWith(this);

--- a/src/extra/plugin/remote.js
+++ b/src/extra/plugin/remote.js
@@ -6,10 +6,7 @@
 // Because returns promises instead of booleans.
 (function($){
 
-window.ParsleyExtend = window.ParsleyExtend || {};
-window.ParsleyExtend = $.extend(true, window.ParsleyExtend, {
-  asyncSupport: true,
-
+$.extend(true, window.Parsley, {
   asyncValidators: {
     'default': {
       fn: function (xhr) {
@@ -27,51 +24,13 @@ window.ParsleyExtend = $.extend(true, window.ParsleyExtend, {
   },
 
   addAsyncValidator: function (name, fn, url, options) {
-    this.asyncValidators[name.toLowerCase()] = {
+    window.Parsley.asyncValidators[name.toLowerCase()] = {
       fn: fn,
       url: url || false,
       options: options || {}
     };
 
     return this;
-  },
-
-  asyncValidate: function () {
-    if ('ParsleyForm' === this.__class__)
-      return this._asyncValidateForm.apply(this, arguments);
-
-    return this._asyncValidateField.apply(this, arguments);
-  },
-
-  asyncIsValid: function () {
-    if ('ParsleyField' === this.__class__)
-      return this._asyncIsValidField.apply(this, arguments);
-
-    return this._asyncIsValidForm.apply(this, arguments);
-  },
-
-  onSubmitValidate: function (event) {
-    var that = this;
-
-    // This is a Parsley generated submit event, do not validate, do not prevent, simply exit and keep normal behavior
-    if (true === event.parsley)
-      return;
-
-    // Clone the event object
-    this.submitEvent = $.extend(true, {}, event);
-
-    // Prevent form submit and immediately stop its event propagation
-    if (event instanceof $.Event) {
-      event.stopImmediatePropagation();
-      event.preventDefault();
-    }
-
-    return this._asyncValidateForm(undefined, event)
-      .done(function () {
-        // If user do not have prevented the event, re-submit form
-        if (that._trigger('submit') && !that.submitEvent.isDefaultPrevented())
-          that.$element.trigger($.extend($.Event('submit'), { parsley: true }));
-      });
   },
 
   eventValidate: function (event) {
@@ -83,185 +42,66 @@ window.ParsleyExtend = $.extend(true, window.ParsleyExtend, {
         return;
 
     this._ui.validatedOnce = true;
-    this.asyncValidate();
+    this.whenValidate();
+  }
+});
+
+window.ParsleyValidator.addValidator('remote', {
+  requirementType: {
+    '': 'string',
+    'validator': 'string',
+    'reverse': 'boolean',
+    'options': 'object'
   },
 
-  // Returns Promise
-  _asyncValidateForm: function (group, event) {
+  validateString: function (value, url, options, instance) {
     var
-      that = this,
-      promises = [];
-
-    this._refreshFields();
-
-    this._trigger('validate');
-
-    for (var i = 0; i < this.fields.length; i++) {
-
-      // do not validate a field if not the same as given validation group
-      if (group && group !== this.fields[i].options.group)
-        continue;
-
-      promises.push(this.fields[i]._asyncValidateField());
-    }
-
-    return $.when.apply($, promises)
-      .done(function () {
-        that._trigger('success');
-      })
-      .fail(function () {
-        that._trigger('error');
-      })
-      .always(function () {
-        that._trigger('validated');
-      });
-  },
-
-  _asyncIsValidForm: function (group, force) {
-    var promises = [];
-    this._refreshFields();
-
-    for (var i = 0; i < this.fields.length; i++) {
-
-      // do not validate a field if not the same as given validation group
-      if (group && group !== this.fields[i].options.group)
-        continue;
-
-      promises.push(this.fields[i]._asyncIsValidField(force));
-    }
-
-    return $.when.apply($, promises);
-  },
-
-  _asyncValidateField: function (force) {
-    var that = this;
-
-    this._trigger('validate');
-
-    return this._asyncIsValidField(force)
-      .done(function () {
-        that._trigger('success');
-      })
-      .fail(function () {
-        that._trigger('error');
-      })
-      .always(function () {
-        that._trigger('validated');
-      });
-  },
-
-  _asyncIsValidField: function (force, value) {
-    var
-      deferred = $.Deferred(),
-      remoteConstraintIndex;
-
-    // If regular isValid (matching regular constraints) returns `false`, no need to go further
-    // Directly reject promise, do not run remote validator and save server load
-    if (false === this.isValid(force, value))
-      deferred.rejectWith(this);
-
-    // If regular constraints are valid, and there is a remote validator registered, run it
-    else if ('undefined' !== typeof this.constraintsByName.remote)
-      this._remote(deferred);
-
-    // Otherwise all is good, resolve promise
-    else
-      deferred.resolveWith(this);
-
-    // Return promise
-    return deferred.promise();
-  },
-
-  _remote: function (deferred) {
-    var
-      that = this,
       data = {},
       ajaxOptions,
       csr,
-      validator = this.options.remoteValidator || (true === this.options.remoteReverse ? 'reverse' : 'default');
+      validator = options.validator || (true === options.reverse ? 'reverse' : 'default');
 
-    validator = validator.toLowerCase();
-
-    if ('undefined' === typeof this.asyncValidators[validator])
+    if ('undefined' === typeof window.Parsley.asyncValidators[validator])
       throw new Error('Calling an undefined async validator: `' + validator + '`');
 
     // Fill data with current value
-    data[this.$element.attr('name') || this.$element.attr('id')] = this.getValue();
+    data[instance.$element.attr('name') || instance.$element.attr('id')] = value;
 
     // Merge options passed in from the function with the ones in the attribute
-    this.options.remoteOptions = $.extend(true, this.options.remoteOptions || {} , this.asyncValidators[validator].options);
+    var remoteOptions = $.extend(true, options.options || {} , window.Parsley.asyncValidators[validator].options);
 
     // All `$.ajax(options)` could be overridden or extended directly from DOM in `data-parsley-remote-options`
     ajaxOptions = $.extend(true, {}, {
-      url: this.asyncValidators[validator].url || this.options.remote,
+      url: window.Parsley.asyncValidators[validator].url || url,
       data: data,
       type: 'GET'
-    }, this.options.remoteOptions || {});
+    }, remoteOptions);
 
     // Generate store key based on ajax options
     csr = $.param(ajaxOptions);
 
     // Initialise querry cache
-    if ('undefined' === typeof this._remoteCache)
-      this._remoteCache = {};
+    if ('undefined' === typeof window.Parsley._remoteCache)
+      window.Parsley._remoteCache = {};
 
     // Try to retrieve stored xhr
-    if (!this._remoteCache[csr]) {
-      // Prevent multi burst xhr queries
-      if (this._xhr && 'pending' === this._xhr.state())
-        this._xhr.abort();
+    var xhr = window.Parsley._remoteCache[csr] = window.Parsley._remoteCache[csr] || $.ajax(ajaxOptions);
 
-      // Make ajax call
-      this._xhr = $.ajax(ajaxOptions);
+    var handleXhr = function() {
+      var result = window.Parsley.asyncValidators[validator].fn.call(instance, xhr, url, options);
+      if (!result) // Map falsy results to rejected promise
+        result = $.Deferred().reject();
+      return $.when(result);
+    };
 
-      // Store remote call result to avoid next calls with exact same parameters
-      this._remoteCache[csr] = this._xhr;
-    }
-
-    this._remoteCache[csr]
-      .done(function (data, textStatus, xhr) {
-        that._handleRemoteResult(validator, xhr, deferred);
-      })
-      .fail(function (xhr, status, message) {
-        // If we aborted the query, do not handle nothing for this value
-        if ('abort' === status)
-          return;
-
-        that._handleRemoteResult(validator, xhr, deferred);
-      });
+    return xhr.then(handleXhr, handleXhr);
   },
 
-  _handleRemoteResult: function (validator, xhr, deferred) {
-    // If true, simply resolve and exit
-    if ('function' === typeof this.asyncValidators[validator].fn && this.asyncValidators[validator].fn.call(this, xhr)) {
-      deferred.resolveWith(this);
-
-      return;
-    }
-
-    // Else, create a proper remote validation Violation to trigger right UI
-    this.validationResult = [
-      {assert: this.constraintsByName.remote}
-    ];
-
-    deferred.rejectWith(this);
-  }
+  priority: -1
 });
 
-// Remote validator is just an always true sync validator with lowest (-1) priority possible
-// It will be overloaded in `validateThroughValidator()` that will do the heavy async work
-// This 'hack' is needed not to mess up too much with error messages and stuff in `ParsleyUI`
-window.ParsleyConfig = window.ParsleyConfig || {};
-window.ParsleyConfig.validators = window.ParsleyConfig.validators || {};
-window.ParsleyConfig.validators.remote = {
-  fn: function () {
-    return true;
-  },
-  priority: -1
-};
-
 window.Parsley.on('form:submit', function () {
-  this._remoteCache = {};
+  window.Parsley._remoteCache = {};
 });
 
 })(jQuery);

--- a/src/extra/plugin/remote.js
+++ b/src/extra/plugin/remote.js
@@ -1,9 +1,3 @@
-// `window.ParsleyExtend`, like `ParsleyAbstract`, is inherited by `ParsleyField` and `ParsleyForm`
-// That way, we could add new methods or redefine some for these both classes. In particular case
-// We are adding async validation methods that returns promises, bind them properly to triggered
-// Events like onkeyup when field is invalid or on form submit. These validation methods adds an
-// Extra `remote` validator which could not be simply added like other `ParsleyExtra` validators
-// Because returns promises instead of booleans.
 (function($){
 
 $.extend(true, window.Parsley, {

--- a/src/extra/plugin/remote.js
+++ b/src/extra/plugin/remote.js
@@ -40,7 +40,7 @@ $.extend(true, window.Parsley, {
   }
 });
 
-window.ParsleyValidator.addValidator('remote', {
+window.Parsley.addValidator('remote', {
   requirementType: {
     '': 'string',
     'validator': 'string',

--- a/src/extra/validator/words.js
+++ b/src/extra/validator/words.js
@@ -8,21 +8,21 @@ var countWords = function (string) {
       .split(' ').length;
 };
 
-window.ParsleyValidator.addValidator(
+window.Parsley.addValidator(
 	'minwords',
 	function (value, nbWords) {
 		return countWords(value) >= nbWords;
 	}, 32)
 	.addMessage('en', 'minwords', 'This value needs more words');
 
-window.ParsleyValidator.addValidator(
+window.Parsley.addValidator(
 	'maxwords',
 	function (value, nbWords) {
 		return countWords(value) <= nbWords;
 	}, 32)
 	.addMessage('en', 'maxwords', 'This value needs fewer words');
 
-window.ParsleyValidator.addValidator(
+window.Parsley.addValidator(
 	'words',
 	function (value, arrayRange) {
 		var length = countWords(value);

--- a/src/parsley.js
+++ b/src/parsley.js
@@ -14,7 +14,7 @@ define([
   // An abstract class shared by `ParsleyField` and `ParsleyForm`
   'parsley/abstract',
   // A proxy between Parsley and [Validator.js](http://validatorjs.org)
-  'parsley/validator',
+  'parsley/validator_registry',
   // `ParsleyUI` static class. Handles all UI and UX
   'parsley/ui',
   // `ParsleyForm` Class. Handles form validation
@@ -29,7 +29,7 @@ define([
   'parsley/pubsub',
   // Default en constraints messages
   'i18n/en'
-], function (ParsleyUtils, ParsleyDefaults, ParsleyAbstract, ParsleyValidator, ParsleyUI, ParsleyForm, ParsleyField, ParsleyMultiple, ParsleyFactory) {
+], function (ParsleyUtils, ParsleyDefaults, ParsleyAbstract, ParsleyValidatorRegistry, ParsleyUI, ParsleyForm, ParsleyField, ParsleyMultiple, ParsleyFactory) {
 
   // Inherit `on`, `off` & `trigger` to Parsley:
   var Parsley = $.extend(new ParsleyAbstract(), {
@@ -83,7 +83,7 @@ define([
   // ### Globals
   window.Parsley = window.psly = Parsley;
   window.ParsleyUtils = ParsleyUtils;
-  window.ParsleyValidator = new ParsleyValidator(window.ParsleyConfig.validators, window.ParsleyConfig.i18n);
+  window.ParsleyValidator = new ParsleyValidatorRegistry(window.ParsleyConfig.validators, window.ParsleyConfig.i18n);
 
   // ### ParsleyUI
   // UI is a separate class that only listens to some events and then modifies the DOM accordingly

--- a/src/parsley.js
+++ b/src/parsley.js
@@ -83,7 +83,17 @@ define([
   // ### Globals
   window.Parsley = window.psly = Parsley;
   window.ParsleyUtils = ParsleyUtils;
-  window.ParsleyValidator = new ParsleyValidatorRegistry(window.ParsleyConfig.validators, window.ParsleyConfig.i18n);
+
+  // ### Define methods that forward to the registry, and deprecate all access except through window.Parsley
+  var registry = window.Parsley._validatorRegistry = new ParsleyValidatorRegistry(window.ParsleyConfig.validators, window.ParsleyConfig.i18n);
+  window.ParsleyValidator = {};
+  $.each('setLocale addCatalog addMessage getErrorMessage formatMessage addValidator updateValidator removeValidator'.split(' '), function (i, method) {
+    window.Parsley[method] = $.proxy(registry, method);
+    window.ParsleyValidator[method] = function () {
+      ParsleyUtils.warnOnce('Accessing the method `'+ method +'` through ParsleyValidator is deprecated. Simply call `window.Parsley.' + method + '(...)`');
+      return window.Parsley[method].apply(window.Parsley, arguments);
+    };
+  });
 
   // ### ParsleyUI
   // UI is a separate class that only listens to some events and then modifies the DOM accordingly

--- a/src/parsley.js
+++ b/src/parsley.js
@@ -13,7 +13,7 @@ define([
   'parsley/defaults',
   // An abstract class shared by `ParsleyField` and `ParsleyForm`
   'parsley/abstract',
-  // A proxy between Parsley and [Validator.js](http://validatorjs.org)
+  // A registry of all Parsley validators (built-in and custom)
   'parsley/validator_registry',
   // `ParsleyUI` static class. Handles all UI and UX
   'parsley/ui',

--- a/src/parsley/abstract.js
+++ b/src/parsley/abstract.js
@@ -24,11 +24,6 @@ define('parsley/abstract', [
       this.actualizeOptions();
     },
 
-    // ParsleyValidator validate proxy function . Could be replaced by third party scripts
-    validateThroughValidator: function (value, constraints, priority) {
-      return window.ParsleyValidator.validate(value, constraints, priority);
-    },
-
     _listeners: null,
 
     // Register a callback for the given event name.

--- a/src/parsley/abstract.js
+++ b/src/parsley/abstract.js
@@ -114,6 +114,11 @@ define('parsley/abstract', [
       this._trigger('destroy');
     },
 
+    asyncIsValid: function() {
+      ParsleyUtils.warnOnce("asyncIsValid is deprecated; please use whenIsValid instead");
+      return this.whenValid.apply(this, arguments);
+    },
+
     _findRelatedMultiple: function() {
       return this.parent.$element.find('[' + this.options.namespace + 'multiple="' + this.options.multiple +'"]');
     }

--- a/src/parsley/abstract.js
+++ b/src/parsley/abstract.js
@@ -4,7 +4,7 @@ define('parsley/abstract', [
   var ParsleyAbstract = function () {};
 
   ParsleyAbstract.prototype = {
-    asyncSupport: false,
+    asyncSupport: true, // Deprecated
 
     actualizeOptions: function () {
       ParsleyUtils.attr(this.$element, this.options.namespace, this.domOptions);

--- a/src/parsley/factory/constraint.js
+++ b/src/parsley/factory/constraint.js
@@ -1,40 +1,21 @@
 define('parsley/factory/constraint', [
-  'parsley/utils'
-], function (ParsleyUtils) {
+  'parsley/utils',
+  'parsley/validator',
+], function (ParsleyUtils, ParsleyValidator) {
   var ConstraintFactory = function (parsleyField, name, requirements, priority, isDomConstraint) {
-    var assert = {};
-
     if (!new RegExp('ParsleyField').test(parsleyField.__class__))
       throw new Error('ParsleyField or ParsleyFieldMultiple instance expected');
 
-    if ('function' === typeof window.ParsleyValidator.validators[name])
-      assert = window.ParsleyValidator.validators[name](requirements);
-    if ('Assert' !== assert.__parentClass__)
-      throw new Error('Valid validator expected');
+    var validatorSpec = window.ParsleyValidator.validators[name];
+    var validator = new ParsleyValidator(validatorSpec);
 
-    var getPriority = function () {
-      if ('undefined' !== typeof parsleyField.options[name + 'Priority'])
-        return parsleyField.options[name + 'Priority'];
-
-      return assert.priority || 2;
-    };
-
-    priority = priority || getPriority();
-
-    // If validator have a requirementsTransformer, execute it
-    if ('function' === typeof assert.requirementsTransformer) {
-      requirements = assert.requirementsTransformer();
-      // rebuild assert with new requirements
-      assert = window.ParsleyValidator.validators[name](requirements);
-    }
-
-    return $.extend(assert, {
+    return {
+      validator: validator,
       name: name,
       requirements: requirements,
-      priority: priority,
-      groups: [priority],
-      isDomConstraint: isDomConstraint || ParsleyUtils.checkAttr(parsleyField.$element, parsleyField.options.namespace, name)
-    });
+      priority: priority || parsleyField.options[name + 'Priority'] || validator.priority || 2,
+      isDomConstraint: true === isDomConstraint
+    };
   };
 
   return ConstraintFactory;

--- a/src/parsley/factory/constraint.js
+++ b/src/parsley/factory/constraint.js
@@ -9,14 +9,35 @@ define('parsley/factory/constraint', [
     var validatorSpec = window.ParsleyValidator.validators[name];
     var validator = new ParsleyValidator(validatorSpec);
 
-    return {
+    $.extend(this, {
       validator: validator,
       name: name,
       requirements: requirements,
       priority: priority || parsleyField.options[name + 'Priority'] || validator.priority,
       isDomConstraint: true === isDomConstraint
-    };
+    });
+    this._parseRequirements(parsleyField.options);
   };
 
+  var capitalize = function(str) {
+    var cap = str[0].toUpperCase();
+    return cap + str.slice(1);
+  };
+
+  ConstraintFactory.prototype = {
+    validate: function(value, instance) {
+      var args = this.requirementList.slice(0); // Make copy
+      args.unshift(value);
+      args.push(instance);
+      return this.validator.validate.apply(this.validator, args);
+    },
+
+    _parseRequirements: function(options) {
+      var that = this;
+      this.requirementList = this.validator.parseRequirements(this.requirements, function(key) {
+        return options[that.name + capitalize(key)];
+      });
+    }
+  };
   return ConstraintFactory;
 });

--- a/src/parsley/factory/constraint.js
+++ b/src/parsley/factory/constraint.js
@@ -6,7 +6,7 @@ define('parsley/factory/constraint', [
     if (!new RegExp('ParsleyField').test(parsleyField.__class__))
       throw new Error('ParsleyField or ParsleyFieldMultiple instance expected');
 
-    var validatorSpec = window.ParsleyValidator.validators[name];
+    var validatorSpec = window.Parsley._validatorRegistry.validators[name];
     var validator = new ParsleyValidator(validatorSpec);
 
     $.extend(this, {

--- a/src/parsley/factory/constraint.js
+++ b/src/parsley/factory/constraint.js
@@ -13,7 +13,7 @@ define('parsley/factory/constraint', [
       validator: validator,
       name: name,
       requirements: requirements,
-      priority: priority || parsleyField.options[name + 'Priority'] || validator.priority || 2,
+      priority: priority || parsleyField.options[name + 'Priority'] || validator.priority,
       isDomConstraint: true === isDomConstraint
     };
   };

--- a/src/parsley/field.js
+++ b/src/parsley/field.js
@@ -273,7 +273,7 @@ define('parsley/field', [
         value = value.replace(/\s{2,}/g, ' ');
 
       if (('trim' === this.options.whitespace) || ('squish' === this.options.whitespace) || (true === this.options.trimValue))
-        value = value.replace(/^\s+|\s+$/g, '');
+        value = ParsleyUtils.trimString(value);
 
       return value;
     },

--- a/src/parsley/field.js
+++ b/src/parsley/field.js
@@ -106,7 +106,7 @@ define('parsley/field', [
       $.each(groupedConstraints, function(_, constraints) {
         var promise = $.when.apply($,
           $.map(constraints, function(constraint) {
-            var result = constraint.validator.parseAndValidate(value, constraint.requirements);
+            var result = constraint.validate(value, that);
             if (false === result)
               result = $.Deferred().reject();
             return $.when(result).fail(function() {

--- a/src/parsley/field.js
+++ b/src/parsley/field.js
@@ -53,9 +53,9 @@ define('parsley/field', [
       this._trigger('validate');
 
       return this.whenValid(force, this.value)
-      .done(function()   { that._trigger('success'); })
-      .fail(function()   { that._trigger('error'); })
-      .always(function() { that._trigger('validated'); });
+        .done(function()   { that._trigger('success'); })
+        .fail(function()   { that._trigger('error'); })
+        .always(function() { that._trigger('validated'); });
     },
 
     hasConstraints: function () {

--- a/src/parsley/field.js
+++ b/src/parsley/field.js
@@ -29,8 +29,7 @@ define('parsley/field', [
   ParsleyField.prototype = {
     // # Public API
     // Validate field and trigger some events for mainly `ParsleyUI`
-    // @returns a promise that will either succeed (field valid) or fail,
-    // in which case the result is an array of Violation.
+    // @returns true or an array of the validators that failed.
     validate: function (force) {
       this.value = this.getValue();
 

--- a/src/parsley/field.js
+++ b/src/parsley/field.js
@@ -166,7 +166,7 @@ define('parsley/field', [
     */
     addConstraint: function (name, requirements, priority, isDomConstraint) {
 
-      if (window.ParsleyValidator.validators[name]) {
+      if (window.Parsley._validatorRegistry.validators[name]) {
         var constraint = new ConstraintFactory(this, name, requirements, priority, isDomConstraint);
 
         // if constraint already exist, delete it and push new version

--- a/src/parsley/form.js
+++ b/src/parsley/form.js
@@ -31,8 +31,8 @@ define('parsley/form', [
       event.preventDefault();
 
       this.whenValidate(undefined, undefined, event)
-      .done(function() { that._submit(); })
-      .always(function() { that._submitSource = null; });
+        .done(function() { that._submit(); })
+        .always(function() { that._submitSource = null; });
 
       return this;
     },
@@ -81,9 +81,9 @@ define('parsley/form', [
         });
       });
       return $.when.apply($, promises)
-      .done(  function() { that._trigger('success'); })
-      .fail(  function() { that.validationResult = false; that._trigger('error'); })
-      .always(function() { that._trigger('validated'); });
+        .done(  function() { that._trigger('success'); })
+        .fail(  function() { that.validationResult = false; that._trigger('error'); })
+        .always(function() { that._trigger('validated'); });
     },
 
     // Iterate over refreshed fields, and stop on first failure.

--- a/src/parsley/ui.js
+++ b/src/parsley/ui.js
@@ -175,9 +175,9 @@ define('parsley/ui', [
       var customConstraintErrorMessage = constraint.name + 'Message';
 
       if ('undefined' !== typeof fieldInstance.options[customConstraintErrorMessage])
-        return window.ParsleyValidator.formatMessage(fieldInstance.options[customConstraintErrorMessage], constraint.requirements);
+        return window.Parsley.formatMessage(fieldInstance.options[customConstraintErrorMessage], constraint.requirements);
 
-      return window.ParsleyValidator.getErrorMessage(constraint);
+      return window.Parsley.getErrorMessage(constraint);
     },
 
     _diff: function (newResult, oldResult, deep) {

--- a/src/parsley/utils.js
+++ b/src/parsley/utils.js
@@ -96,6 +96,10 @@ define('parsley/utils', function () {
       pastWarnings = {};
     },
 
+    trimString: function(string) {
+      return string.replace(/^\s+|\s+$/g, '');
+    },
+
     // Object.create polyfill, see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/create#Polyfill
     objectCreate: Object.create || (function () {
       var Object = function () {};

--- a/src/parsley/validator.js
+++ b/src/parsley/validator.js
@@ -1,0 +1,132 @@
+define('parsley/validator', [
+    'parsley/utils'
+], function (ParsleyUtils) {
+
+  var requirementConverters = {
+    string: function(string) {
+      return string;
+    },
+    integer: function(string) {
+      if (isNaN(string))
+        throw 'Requirement is not an integer: "' + string + '"';
+      return parseInt(string, 10);
+    },
+    number: function(string) {
+      if (isNaN(string))
+        throw 'Requirement is not a number: "' + string + '"';
+      return parseFloat(string);
+    },
+    reference: function(string) { // Unused for now
+      var result = $(string);
+      if (result.length === 0)
+        throw 'No such reference: "' + string + '"';
+      return result;
+    },
+    regexp: function(regexp) {
+      var flags = '';
+
+      // Test if RegExp is literal, if not, nothing to be done, otherwise, we need to isolate flags and pattern
+      if (!!(/^\/.*\/(?:[gimy]*)$/.test(regexp))) {
+        // Replace the regexp literal string with the first match group: ([gimy]*)
+        // If no flag is present, this will be a blank string
+        flags = regexp.replace(/.*\/([gimy]*)$/, '$1');
+        // Again, replace the regexp literal string with the first match group:
+        // everything excluding the opening and closing slashes and the flags
+        regexp = regexp.replace(new RegExp('^/(.*?)/' + flags + '$'), '$1');
+      }
+      return new RegExp(regexp, flags);
+    }
+  };
+
+  var convertArrayRequirement = function(string, length) {
+    var m = string.match(/^\s*\[(.*)\]\s*$/)
+    if (!m)
+      throw 'Requirement is not an array: "' + string + '"';
+    var values = m[1].split(',').map(ParsleyUtils.trimString);
+    if (values.length !== length)
+      throw 'Requirement has ' + values.length + ' values when ' + length + ' are needed';
+    return values;
+  };
+
+  var convertRequirement = function(requirementType, string) {
+    var converter = requirementConverters[requirementType || 'string'];
+    if (!converter)
+      throw 'Unknown requirement specification: "' + requirementType + '"';
+    return converter(string);
+  }
+
+
+  // A Validator needs to implement two methods:
+  // `validate(value, requirements...)`, returning `true`, `false`
+  // `parseRequirements(requirementString), returning an array of values
+
+  var ParsleyValidator = function(spec) {
+    $.extend(this, spec);
+    if (spec.parametersTransformer) {
+      ParsleyUtils.warnOnce('parametersTransformer is deprecated. Use requirementType or define parseRequirements instead');
+      this.parseRequirements = function(requirementString) {
+        var result = spec.parametersTransformer(requirementString)
+        return $.isArray(result) ? result : [result];
+      };
+    }
+  };
+
+  ParsleyValidator.prototype = {
+    parseAndValidate: function(value, requirements) {
+      var args = this.parseRequirements(requirements);
+      args.unshift(value);
+      return this.validate.apply(this, args);
+    },
+
+    // Returns `true` iff the given `value` is valid according the given requirements.
+    validate: function(value, requirementArg1, requirementArg2) {
+      if(this.fn) {
+        // TODO: Guess if array
+        // Legacy style validator:
+        if(arguments.length > 2)
+          requirementArg1 = [].slice.call(arguments, 1);
+        return this.fn.call(this, value, requirementArg1);
+      }
+
+      if ($.isArray(value)) {
+        if (!this.validateMultiple)
+          throw 'Validator ' + this.name + ' does not handle multiple values';
+        return this.validateMultiple.apply(this, arguments);
+      } else {
+        if (this.validateNumber) {
+          if (isNaN(value))
+            return false;
+          value = parseFloat(value);
+          return this.validateNumber.apply(this, arguments);
+        }
+        if (this.validateString) {
+          return this.validateString.apply(this, arguments);
+        }
+        throw 'Validator ' + this.name + ' only handles multiple values';
+      }
+    },
+
+    requirementType: 'string',
+
+    // Parses `requirements` into an array of arguments,
+    // according to `this.requirementType`
+    parseRequirements: function(requirements) {
+      if ('string' !== typeof requirements) {
+        // Assume requirement already parsed
+        // but make sure we return an array
+        return $.isArray(requirements) ? requirements : [requirements];
+      }
+      var type = this.requirementType;
+      if ($.isArray(type)) {
+        var values = convertArrayRequirement(requirements, type.length);
+        for (var i = 0; i < values.length; i++)
+          values[i] = convertRequirement(type[i], values[i]);
+        return values;
+      } else {
+        return [convertRequirement(type, requirements)];
+      }
+    }
+  };
+
+  return ParsleyValidator;
+});

--- a/src/parsley/validator.js
+++ b/src/parsley/validator.js
@@ -61,14 +61,7 @@ define('parsley/validator', [
   // `parseRequirements(requirementString), returning an array of values
 
   var ParsleyValidator = function(spec) {
-    $.extend(this, spec);
-    if (spec.parametersTransformer) {
-      ParsleyUtils.warnOnce('parametersTransformer is deprecated. Use requirementType or define parseRequirements instead');
-      this.parseRequirements = function(requirementString) {
-        var result = spec.parametersTransformer(requirementString)
-        return $.isArray(result) ? result : [result];
-      };
-    }
+    $.extend(true, this, spec);
   };
 
   ParsleyValidator.prototype = {
@@ -89,7 +82,7 @@ define('parsley/validator', [
 
       if ($.isArray(value)) {
         if (!this.validateMultiple)
-          throw 'Validator ' + this.name + ' does not handle multiple values';
+          throw 'Validator `' + this.name + '` does not handle multiple values';
         return this.validateMultiple.apply(this, arguments);
       } else {
         if (this.validateNumber) {

--- a/src/parsley/validator.js
+++ b/src/parsley/validator.js
@@ -106,8 +106,6 @@ define('parsley/validator', [
       }
     },
 
-    requirementType: 'string',
-
     // Parses `requirements` into an array of arguments,
     // according to `this.requirementType`
     parseRequirements: function(requirements) {
@@ -125,7 +123,12 @@ define('parsley/validator', [
       } else {
         return [convertRequirement(type, requirements)];
       }
-    }
+    },
+    // Defaults:
+    requirementType: 'string',
+
+    priority: 2
+
   };
 
   return ParsleyValidator;

--- a/src/parsley/validator.js
+++ b/src/parsley/validator.js
@@ -79,13 +79,12 @@ define('parsley/validator', [
     },
 
     // Returns `true` iff the given `value` is valid according the given requirements.
-    validate: function(value, requirementArg1, requirementArg2) {
-      if(this.fn) {
-        // TODO: Guess if array
-        // Legacy style validator:
-        if(arguments.length > 2)
-          requirementArg1 = [].slice.call(arguments, 1);
-        return this.fn.call(this, value, requirementArg1);
+    validate: function(value, requirementFirstArg) {
+      if(this.fn) { // Legacy style validator
+
+        if(arguments.length > 3)  // If more args then value, requirement, instance...
+          requirementFirstArg = [].slice.call(arguments, 1, -1);  // Skip first arg (value) and last (instance), combining the rest
+        return this.fn.call(this, value, requirementFirstArg);
       }
 
       if ($.isArray(value)) {

--- a/src/parsley/validator_registry.js
+++ b/src/parsley/validator_registry.js
@@ -108,7 +108,11 @@ define('parsley/validator_registry', [
     //    addValidator('custom', {
     //        requirementType: ['integer', 'integer'],
     //        validateString: function(value, from, to) {},
-    //        priority: 22
+    //        priority: 22,
+    //        messages: {
+    //          en: "Hey, that's no good",
+    //          fr: "Aye aye, pas bon du tout",
+    //        }
     //    }
     //
     // Old API was addValidator(name, function, priority)
@@ -146,12 +150,15 @@ define('parsley/validator_registry', [
         validator = {
           fn: validator,
           priority: priority
-        }
+        };
       };
       if (!validator.validate) {
         validator = new ParsleyValidator(validator);
       };
       this.validators[name] = validator;
+
+      for (var locale in validator.messages || {})
+        this.addMessage(locale, name, validator.messages[locale]);
 
       return this;
     },

--- a/src/parsley/validator_registry.js
+++ b/src/parsley/validator_registry.js
@@ -66,7 +66,7 @@ define('parsley/validator_registry', [
       this.validators = $.extend({}, this.validators);
 
       for (var name in validators)
-        this.addValidator(name, validators[name].fn, validators[name].priority, validators[name].requirementsTransformer);
+        this.addValidator(name, validators[name].fn, validators[name].priority);
 
       window.Parsley.trigger('parsley:validator:init');
     },
@@ -103,22 +103,22 @@ define('parsley/validator_registry', [
     },
 
     // Add a new validator
-    addValidator: function (name, fn, priority, requirementsTransformer) {
+    addValidator: function (name, fn, priority) {
       if (this.validators[name])
         ParsleyUtils.warn('Validator "' + name + '" is already defined.');
       else if (ParsleyDefaults.hasOwnProperty(name)) {
         ParsleyUtils.warn('"' + name + '" is a restricted keyword and is not a valid validator name.');
         return;
       };
-      return this._setValidator(name, fn, priority, requirementsTransformer);
+      return this._setValidator(name, fn, priority);
     },
 
-    updateValidator: function (name, fn, priority, requirementsTransformer) {
+    updateValidator: function (name, fn, priority) {
       if (!this.validators[name]) {
         ParsleyUtils.warn('Validator "' + name + '" is not already defined.');
-        return this.addValidator(name, fn, priority, requirementsTransformer);
+        return this.addValidator(name, fn, priority);
       }
-      return this._setValidator(name, fn, priority, requirementsTransformer);
+      return this._setValidator(name, fn, priority);
     },
 
     removeValidator: function (name) {
@@ -130,13 +130,7 @@ define('parsley/validator_registry', [
       return this;
     },
 
-    _setValidator: function (name, fn, priority, requirementsTransformer) {
-      if ('function' === typeof requirementsTransformer) {
-        var originalFn = fn;
-        fn = function(value, requirements) {
-          originalFn(requirementsTransformer(requirements));
-        }
-      }
+    _setValidator: function (name, fn, priority) {
       this.validators[name] = {
         fn: fn,
         priority: priority

--- a/src/parsley/validator_registry.js
+++ b/src/parsley/validator_registry.js
@@ -1,4 +1,4 @@
-define('parsley/validator', [
+define('parsley/validator_registry', [
   'parsley/defaults',
   'validator'
 ], function (ParsleyDefaults, Validator) {
@@ -6,8 +6,8 @@ define('parsley/validator', [
   // This is needed for Browserify usage that requires Validator.js through module.exports
   Validator = 'undefined' !== typeof Validator ? Validator : ('undefined' !== typeof module ? module.exports : null);
 
-  var ParsleyValidator = function (validators, catalog) {
-    this.__class__ = 'ParsleyValidator';
+  var ParsleyValidatorRegistry = function (validators, catalog) {
+    this.__class__ = 'ParsleyValidatorRegistry';
     this.Validator = Validator;
 
     // Default Parsley locale is en
@@ -16,7 +16,7 @@ define('parsley/validator', [
     this.init(validators || {}, catalog || {});
   };
 
-  ParsleyValidator.prototype = {
+  ParsleyValidatorRegistry.prototype = {
     init: function (validators, catalog) {
       this.catalog = catalog;
       // Copy prototype's validators:
@@ -283,5 +283,5 @@ define('parsley/validator', [
     }
   };
 
-  return ParsleyValidator;
+  return ParsleyValidatorRegistry;
 });

--- a/src/parsley/validator_registry.js
+++ b/src/parsley/validator_registry.js
@@ -104,6 +104,15 @@ define('parsley/validator_registry', [
     },
 
     // Add a new validator
+    //
+    //    addValidator('custom', {
+    //        requirementType: ['integer', 'integer'],
+    //        validateString: function(value, from, to) {},
+    //        priority: 22
+    //    }
+    //
+    // Old API was addValidator(name, function, priority)
+    //
     addValidator: function (name, arg1, arg2) {
       if (this.validators[name])
         ParsleyUtils.warn('Validator "' + name + '" is already defined.');

--- a/test/features/abstract.js
+++ b/test/features/abstract.js
@@ -18,7 +18,6 @@ define(function () {
         var parsleyField = $('#element').parsley();
         parsleyField.validate();
         expect($('#parsley-id-' + parsleyField.__id__ + ' li').length).to.be(1);
-
         parsleyField.reset();
         expect($('#parsley-id-' + parsleyField.__id__ + ' li').length).to.be(0);
       });

--- a/test/features/extra.js
+++ b/test/features/extra.js
@@ -5,15 +5,16 @@ define('features/extra', [
   'extra/validator/notequalto',
 ], function () {
 
-  return function (ParsleyValidatorRegistry) {
+  return function (ParsleyValidator, ParsleyValidatorRegistry) {
     describe('ParsleyExtras validators', function () {
       it('should have dateiso validator', function () {
         expect(window.ParsleyConfig.validators).to.have.key('dateiso');
-        var parsleyValidator = new ParsleyValidatorRegistry(window.ParsleyConfig.validators);
+        var validatorRegistry = new ParsleyValidatorRegistry(window.ParsleyConfig.validators || {}, window.ParsleyConfig.i18n || {});
 
         var expectValidation = function(value, name, requirements) {
-          var validator = parsleyValidator.validators[name](requirements);
-          return expect(parsleyValidator.validate(value, validator));
+          var validatorSpec = validatorRegistry.validators[name];
+          var validator = new ParsleyValidator(validatorSpec);
+          return expect(validator.parseAndValidate(value, requirements));
         };
 
         expectValidation('',           'dateiso').not.to.be(true);

--- a/test/features/extra.js
+++ b/test/features/extra.js
@@ -26,7 +26,7 @@ define('features/extra', [
         expectValidation('1986-12-01', 'dateiso').to.be(true);
       });
       it('should have gt validator', function () {
-        expect(window.ParsleyValidator.validators).to.have.key('gt');
+        expect(window.Parsley._validatorRegistry.validators).to.have.key('gt');
         var number = 5;
 
         // Check with a selector
@@ -52,7 +52,7 @@ define('features/extra', [
         $('#gt').remove();
       });
       it('should have gte validator', function () {
-        expect(window.ParsleyValidator.validators).to.have.key('gte');
+        expect(window.Parsley._validatorRegistry.validators).to.have.key('gte');
         var number = 5;
 
         // Check with a selector
@@ -78,7 +78,7 @@ define('features/extra', [
         $('#gte').remove();
       });
       it('should have lt validator', function () {
-        expect(window.ParsleyValidator.validators).to.have.key('lt');
+        expect(window.Parsley._validatorRegistry.validators).to.have.key('lt');
         var number = 5;
 
         // Check with a selector
@@ -104,7 +104,7 @@ define('features/extra', [
         $('#lt').remove();
       });
       it('should have lte validator', function () {
-        expect(window.ParsleyValidator.validators).to.have.key('lte');
+        expect(window.Parsley._validatorRegistry.validators).to.have.key('lte');
         var number = 5;
 
         // Check with a selector
@@ -130,7 +130,7 @@ define('features/extra', [
         $('#lte').remove();
       });
       it('should have a minwords validator', function () {
-        expect(window.ParsleyValidator.validators).to.have.key('minwords');
+        expect(window.Parsley._validatorRegistry.validators).to.have.key('minwords');
         $('body').append('<input type="text" id="element" data-parsley-minwords="2" required />');
         expect($('#element').psly().isValid()).to.be(false);
         $('#element').val('foo');
@@ -139,7 +139,7 @@ define('features/extra', [
         expect($('#element').psly().isValid()).to.be(true);
       });
       it('should have a maxwords validator', function () {
-        expect(window.ParsleyValidator.validators).to.have.key('maxwords');
+        expect(window.Parsley._validatorRegistry.validators).to.have.key('maxwords');
         $('body').append('<input type="text" id="element" data-parsley-maxwords="2" required />');
         expect($('#element').psly().isValid()).to.be(false);
         $('#element').val('foo bar');
@@ -148,7 +148,7 @@ define('features/extra', [
         expect($('#element').psly().isValid()).to.be(false);
       });
       it('should have a words validator', function () {
-        expect(window.ParsleyValidator.validators).to.have.key('words');
+        expect(window.Parsley._validatorRegistry.validators).to.have.key('words');
         $('body').append('<input type="text" id="element" data-parsley-words="[2, 4]" required />');
         expect($('#element').psly().isValid()).to.be(false);
         $('#element').val('foo');

--- a/test/features/extra.js
+++ b/test/features/extra.js
@@ -5,11 +5,11 @@ define('features/extra', [
   'extra/validator/notequalto',
 ], function () {
 
-  return function (ParsleyValidator) {
+  return function (ParsleyValidatorRegistry) {
     describe('ParsleyExtras validators', function () {
       it('should have dateiso validator', function () {
         expect(window.ParsleyConfig.validators).to.have.key('dateiso');
-        var parsleyValidator = new ParsleyValidator(window.ParsleyConfig.validators);
+        var parsleyValidator = new ParsleyValidatorRegistry(window.ParsleyConfig.validators);
 
         var expectValidation = function(value, name, requirements) {
           var validator = parsleyValidator.validators[name](requirements);

--- a/test/features/extra.js
+++ b/test/features/extra.js
@@ -14,7 +14,9 @@ define('features/extra', [
         var expectValidation = function(value, name, requirements) {
           var validatorSpec = validatorRegistry.validators[name];
           var validator = new ParsleyValidator(validatorSpec);
-          return expect(validator.parseAndValidate(value, requirements));
+          var argList = validator.parseRequirements(requirements);
+          argList.unshift(value);
+          return expect(validator.validate.apply(validator, argList));
         };
 
         expectValidation('',           'dateiso').not.to.be(true);

--- a/test/features/field.js
+++ b/test/features/field.js
@@ -11,8 +11,6 @@ define(function () {
         $('body').append('<input type="text" id="element" data-parsley-required />');
         var parsleyField = $('#element').parsley();
         expect(parsleyField.constraints.length).to.be(1);
-        expect(parsleyField.constraints[0].__class__).to.be('Required');
-        expect(parsleyField.constraints[0].__parentClass__).to.be('Assert');
         expect(parsleyField.constraints[0].name).to.be('required');
         expect(parsleyField.constraints[0].isDomConstraint).to.be(true);
       });
@@ -20,8 +18,6 @@ define(function () {
         $('body').append('<input type="email" id="element" />');
         var parsleyField = $('#element').parsley();
         expect(parsleyField.constraints.length).to.be(1);
-        expect(parsleyField.constraints[0].__class__).to.be('Email');
-        expect(parsleyField.constraints[0].__parentClass__).to.be('Assert');
         expect(parsleyField.constraints[0].name).to.be('type');
         expect(parsleyField.constraints[0].isDomConstraint).to.be(true);
       });
@@ -40,8 +36,6 @@ define(function () {
         var parsleyField = $('#element').parsley()
           .addConstraint('required', true);
         expect(parsleyField.constraints.length).to.be(1);
-        expect(parsleyField.constraints[0].__class__).to.be('Required');
-        expect(parsleyField.constraints[0].__parentClass__).to.be('Assert');
         expect(parsleyField.constraints[0].name).to.be('required');
         expect(parsleyField.constraints[0].requirements).to.be(true);
         expect(parsleyField.constraints[0].priority).to.be(512);

--- a/test/features/field.js
+++ b/test/features/field.js
@@ -131,7 +131,7 @@ define(function () {
       });
       it('should valid most complex Callback() validator', function () {
         $('body').append('<input type="text" id="element" value="" />');
-        window.ParsleyValidator.addValidator('ismultiple', function (value, multiple) {
+        window.Parsley.addValidator('ismultiple', function (value, multiple) {
           if (!isNaN(parseFloat(value)) && isFinite(value))
             return !(Number(value) % multiple);
 
@@ -149,14 +149,14 @@ define(function () {
         expect(parsleyField.isValid()).to.be(false);
         $('#element').val('9');
         expect(parsleyField.isValid()).to.be(true);
-        window.ParsleyValidator.removeValidator('ismultiple');
+        window.Parsley.removeValidator('ismultiple');
       });
       it('should properly compute constraints on each validation', function () {
         $('body').append('<input type="email" data-parsley-required id="element" />');
-        window.ParsleyValidator.addValidator('foobazer', function (value) {
+        window.Parsley.addValidator('foobazer', function (value) {
           return 'foobar' === value;
         }, 2);
-        window.ParsleyValidator.addValidator('ismultiple', function (value, multiple) {
+        window.Parsley.addValidator('ismultiple', function (value, multiple) {
           if (!isNaN(parseFloat(value)) && isFinite(value))
             return !(Number(value) % multiple);
 
@@ -175,8 +175,8 @@ define(function () {
           .removeConstraint('ismultiple')
           .refreshConstraints();
         expect(parsleyField.constraints.length).to.be(2);
-        window.ParsleyValidator.removeValidator('foobazer');
-        window.ParsleyValidator.removeValidator('ismultiple');
+        window.Parsley.removeValidator('foobazer');
+        window.Parsley.removeValidator('ismultiple');
       });
       it('should handle constraints priorities on validation', function () {
         $('body').append('<input type="email" pattern="[A-F][0-9]{5}" required id="element" />');

--- a/test/features/form.js
+++ b/test/features/form.js
@@ -234,7 +234,7 @@ define(function () {
         .appendTo('body')
         .parsley();
         var deferred;
-        window.ParsleyValidator.addValidator('custom', function() {
+        window.Parsley.addValidator('custom', function() {
           called++;
           deferred = $.Deferred();
           return deferred.promise();
@@ -244,7 +244,7 @@ define(function () {
           evt.preventDefault();
           expect(evt.parsley).to.be(true); // Sanity check
           expect(shouldSubmit).to.be(true);
-          window.ParsleyValidator.removeValidator('custom');
+          window.Parsley.removeValidator('custom');
           done();
         })
         $('#element').submit();

--- a/test/features/form.js
+++ b/test/features/form.js
@@ -92,41 +92,27 @@ define(function () {
           // group name on single required field, without value
           expect(parsleyForm.isValid('qux')).to.be(false);
       });
-      it('should handle `onFormSubmit` validation', function () {
+      it('should handle form submission correctly', function (done) {
         $('body').append(
-          '<form id="element" data-parsley-trigger="change">'                 +
-            '<input id="field1" type="text" data-parsley-required="true" />'  +
-            '<div id="field2"></div>'                                         +
-            '<textarea id="field3" data-parsley-notblank="true"></textarea>'  +
+          '<form id="element">'                 +
+            '<input id="field1" type="text" name="nick" data-parsley-required="true" />'  +
+            '<div id="field2" name="comment"></div>'                                         +
+            '<input type="submit" name="foo" value="bar" />'  +
+            '<input type="submit" name="foo" value="other" />'  +
           '</form>');
           var parsleyForm = $('#element').parsley();
 
-          // parsley.remote hack because if valid, parsley remote re-send form
-          $('#element').parsley().on('form:validate', function () {
-            if (this.asyncSupport)
-              this.submitEvent._originalPreventDefault();
-          });
-
-          var event = $.Event();
-          // parsley.remote hack
-          event._originalPreventDefault = event.preventDefault;
-          event.preventDefault = sinon.spy();
-          parsleyForm.onSubmitValidate(event);
-          expect(event.preventDefault.called).to.be(true);
+          $('#element input:last').click();
+          // Form should not be submitted at this point
 
           $('#field1').val('foo');
-          $('#field3').val('foo');
-
-          event = $.Event();
-          // parsley.remote hack
-          event._originalPreventDefault = event.preventDefault;
-          event.preventDefault = sinon.spy();
-          parsleyForm.onSubmitValidate(event);
-
-          if (!parsleyForm.asyncSupport)
-            expect(event.preventDefault.called).to.be(false);
-          else
-            expect(event.preventDefault.called).to.be(true);
+          $('#element').on('submit', function(evt) {
+            if(evt.parsley) {
+              evt.preventDefault();
+              done();
+            }
+          });
+          $('#element input:last').click();
       });
       it('should have a force option for validate and isValid methods', function () {
         $('body').append(
@@ -239,6 +225,42 @@ define(function () {
         parsleyForm.validate();
         parsleyForm.validate();
         expect(steps).to.eql(['field: excluded', 'form: excluded', 'field: detached', 'form: detached', 'field: removed', 'form: removed']);
+      });
+
+      it('should handle validators returning promises', function (done) {
+        var called = 0;
+        var shouldSubmit = false;
+        var form = $('<form id="element"><input data-parsley-custom value="x"/></form>')
+        .appendTo('body')
+        .parsley();
+        var deferred;
+        window.ParsleyValidator.addValidator('custom', function() {
+          called++;
+          deferred = $.Deferred();
+          return deferred.promise();
+        });
+
+        $('#element').on('submit', function(evt) {
+          evt.preventDefault();
+          expect(evt.parsley).to.be(true); // Sanity check
+          expect(shouldSubmit).to.be(true);
+          window.ParsleyValidator.removeValidator('custom');
+          done();
+        })
+        $('#element').submit();
+        expect(called).to.eql(1);
+        deferred.reject();
+
+        var promise = form.whenValidate();
+        expect(called).to.eql(2);
+        expect(promise.state()).to.eql('pending');
+        deferred.reject();
+        expect(promise.state()).to.eql('rejected');
+
+        $('#element').submit();
+        expect(called).to.eql(3);
+        shouldSubmit = true;
+        deferred.resolve();
       });
 
       afterEach(function () {

--- a/test/features/remote.js
+++ b/test/features/remote.js
@@ -33,7 +33,7 @@ define('features/remote', [
         // Restore ParsleyExtend from remote
         window.ParsleyExtend = window._remoteParsleyExtend;
         window.ParsleyConfig = window._remoteParsleyConfig;
-        window.ParsleyValidator.init(window.ParsleyConfig.validators, window.ParsleyConfig.i18n);
+        window.Parsley._validatorRegistry.init(window.ParsleyConfig.validators, window.ParsleyConfig.i18n);
       });
       beforeEach(function() {
         delete window.Parsley._remoteCache;

--- a/test/features/remote.js
+++ b/test/features/remote.js
@@ -10,6 +10,25 @@ define('features/remote', [
 
   return function () {
     describe('ParsleyRemote', function () {
+      var stubbed = false;
+      var stubAjax = function(status) {
+        restoreAjax();
+        var deferred = $.Deferred();
+        var xhr = $.extend(deferred.promise(), { status: status });
+        if(status === 200)
+          deferred.resolve({}, 'success', 'xhr');
+        else
+          deferred.reject(xhr, 'error', 'error');
+        sinon.stub($, 'ajax').returns(xhr);
+        stubbed = true;
+      }
+      var restoreAjax = function() {
+        if (stubbed)
+          $.ajax.restore();
+        stubbed = false;
+      }
+
+      afterEach(restoreAjax);
       before(function () {
         // Restore ParsleyExtend from remote
         window.ParsleyExtend = window._remoteParsleyExtend;
@@ -26,50 +45,41 @@ define('features/remote', [
         $('body').append('<input type="text" data-parsley-remote="http://foo.bar" id="element" required name="element" value="foo" />');
         var parsleyInstance = $('#element').parsley();
 
-        sinon.stub($, 'ajax').returns($.Deferred().reject({ status: 400, state: function () { return 'rejected' } }, 'error', 'error'));
+        stubAjax(400);
 
         parsleyInstance.whenValid()
           .fail(function () {
-            $.ajax.restore();
-            sinon.stub($, 'ajax').returns($.Deferred().resolve({}, 'success', { status: 200, state: function () { return 'resolved' } }));
+            stubAjax(200);
 
             $('#element').val('bar');
             parsleyInstance.whenValid()
-              .done(function () {
-                $.ajax.restore();
-                done();
-              });
+              .done(function () { done() });
           });
       });
       it('should handle remote reverse option', function (done) {
         $('body').append('<input type="text" data-parsley-remote="http://foo.bar" id="element" data-parsley-remote-reverse="true" required name="element" value="baz" />');
         var parsleyInstance = $('#element').parsley();
 
-        sinon.stub($, 'ajax').returns($.Deferred().resolve({}, 'success', { status: 200, state: function () { return 'resolved' } }));
+        stubAjax(200);
         parsleyInstance.whenValid()
           .fail(function () {
-            $.ajax.restore();
-            sinon.stub($, 'ajax').returns($.Deferred().reject({ status: 400, state: function () { return 'rejected' } }, 'error', 'error'));
+            stubAjax(400);
 
             $('#element').val('bux');
             parsleyInstance.whenValid()
-              .done(function () {
-                $.ajax.restore();
-                done();
-              });
+              .done(function () { done() });
           });
       });
       it('should handle remote options', function (done) {
         $('body').append('<input type="text" data-parsley-remote="http://foo.bar" id="element" data-parsley-remote-options=\'{ "type": "POST", "data": {"foo": "bar"} }\' required name="element" value="baz" />');
         var parsleyInstance = $('#element').parsley();
 
-        sinon.stub($, 'ajax').returns($.Deferred().resolve({}, 'success', { status: 200, state: function () { return 'resolved' } }));
+        stubAjax(200);
         parsleyInstance.whenValid()
           .done(function () {
             expect($.ajax.calledWithMatch({ type: "POST" })).to.be(true);
             expect($.ajax.calledWithMatch({ url: "http://foo.bar" })).to.be(true);
             expect($.ajax.calledWithMatch({ data: { "foo": "bar", "element": "baz" } })).to.be(true);
-            $.ajax.restore();
             done();
           });
       });
@@ -77,16 +87,12 @@ define('features/remote', [
         $('body').append('<input type="text" data-parsley-remote="http://foo.bar" id="element" required name="element" value="foo" />');
         var parsleyInstance = $('#element').parsley();
 
-        var deferred = $.Deferred();
-        var xhr = $.extend(deferred.promise(), {status: 200, stubbed: true});
-        sinon.stub($, 'ajax').returns(xhr);
-        deferred.resolve({}, 'success', xhr);
+        stubAjax(200);
         parsleyInstance.whenValid()
           .done(function () {
             expect($.ajax.calledOnce).to.be(true);
             expect($.ajax.calledWithMatch({ data: { "element": "foo" } })).to.be(true);
-            $.ajax.restore();
-            sinon.stub($, 'ajax').returns($.Deferred().reject({ status: 400, state: function () { return 'rejected' } }, 'error', 'error'));
+            stubAjax(400);
 
             $('#element').val('bar');
             parsleyInstance.whenValid()
@@ -94,15 +100,13 @@ define('features/remote', [
                 expect($.ajax.calledOnce).to.be(true);
                 expect($.ajax.calledWithMatch({ data: { "element": "bar" } })).to.be(true);
 
-                $.ajax.restore();
-                sinon.stub($, 'ajax').returns($.Deferred().resolve({}, 'success', { status: 200, state: function () { return 'resolved' } }));
+                stubAjax(200);
                 $('#element').val('foo');
 
                 parsleyInstance.whenValid()
                   .done(function () {
                     expect($.ajax.callCount).to.be(0);
                     expect($.ajax.calledOnce).to.be(false);
-                    $.ajax.restore();
                     done();
                   });
               });
@@ -117,24 +121,19 @@ define('features/remote', [
         $('body').append('<input type="text" data-parsley-remote="http://foo.bar" id="element" data-parsley-remote-validator="custom" required name="element" value="foobar" />');
         var parsleyInstance = $('#element').parsley();
 
-        sinon.stub($, 'ajax').returns($.Deferred().resolve({}, 'success', { status: 200, state: function () { return 'resolved' } }));
+        stubAjax(200);
         parsleyInstance.whenValid()
           .fail(function () {
-            $.ajax.restore();
-            sinon.stub($, 'ajax').returns($.Deferred().reject({ status: 400, state: function () { return 'rejected' } }, 'error', 'error'));
+            stubAjax(400);
 
             $('#element').val('foobaz');
             parsleyInstance.whenValid()
               .fail(function () {
-                $.ajax.restore();
-                sinon.stub($, 'ajax').returns($.Deferred().reject({ status: 404, state: function () { return 'rejected' } }, 'error', 'not found'));
+                stubAjax(404);
 
                 $('#element').val('fooquux');
                 parsleyInstance.whenValid()
-                  .done(function () {
-                    $.ajax.restore();
-                    done();
-                  });
+                  .done(function () { done() });
               });
           });
       });
@@ -146,11 +145,10 @@ define('features/remote', [
           return xhr.status === 404;
         }, 'http://foobar.baz');
 
-        sinon.stub($, 'ajax').returns($.Deferred().resolve({}, 'success', { status: 200, state: function () { return 'resolved' } }));
+        stubAjax(200);
         parsleyInstance.whenValid()
           .fail(function () {
             expect($.ajax.calledWithMatch({ url: "http://foobar.baz" })).to.be(true);
-            $.ajax.restore();
             done();
           });
       });
@@ -162,11 +160,10 @@ define('features/remote', [
           expect(this.__class__).to.be('ParsleyField');
         }, 'http://foobar.baz');
 
-        sinon.stub($, 'ajax').returns($.Deferred().resolve({}, 'success', { status: 200, state: function () { return 'resolved' } }));
+        stubAjax(200);
         parsleyInstance.whenValid()
           .fail(function () {
             expect($.ajax.calledWithMatch({ url: "http://foobar.baz" })).to.be(true);
-            $.ajax.restore();
             done();
           });
       });

--- a/test/features/remote.js
+++ b/test/features/remote.js
@@ -110,7 +110,7 @@ define('features/remote', [
       });
       // custom validator needed for this test is registered in `tests.js` before running this suite
       it('should handle remote validator option', function (done) {
-        $('body').append('<input type="text" data-parsley-remote="http://foo.bar" id="element" data-parsley-remote-validator="cUSTom" required name="element" value="foobar" />');
+        $('body').append('<input type="text" data-parsley-remote="http://foo.bar" id="element" data-parsley-remote-validator="custom" required name="element" value="foobar" />');
         var parsleyInstance = $('#element').parsley();
 
         sinon.stub($, 'ajax').returns($.Deferred().resolve({}, 'success', { status: 200, state: function () { return 'resolved' } }));

--- a/test/features/remote.js
+++ b/test/features/remote.js
@@ -108,8 +108,12 @@ define('features/remote', [
               });
           });
       });
-      // custom validator needed for this test is registered in `tests.js` before running this suite
+
       it('should handle remote validator option', function (done) {
+        window.Parsley.addAsyncValidator('custom', function(xhr) {
+          return xhr.status === 404;
+        });
+
         $('body').append('<input type="text" data-parsley-remote="http://foo.bar" id="element" data-parsley-remote-validator="custom" required name="element" value="foobar" />');
         var parsleyInstance = $('#element').parsley();
 

--- a/test/features/ui.js
+++ b/test/features/ui.js
@@ -331,13 +331,13 @@ define(function () {
       });
       it('should handle custom error message for validators with compound names', function () {
         $('body').append('<input type="text" value="1" id="element" data-parsley-custom-validator="2" data-parsley-custom-validator-message="custom-validator error"/>');
-        window.ParsleyValidator.addValidator('customValidator', function (value, requirement) {
+        window.Parsley.addValidator('customValidator', function (value, requirement) {
           return requirement === value;
         }, 32);
         var parsleyField = $('#element').psly();
         parsleyField.validate();
         expect($('ul#parsley-id-' + parsleyField.__id__ + ' li').text()).to.be('custom-validator error');
-        window.ParsleyValidator.removeValidator('customValidator');
+        window.Parsley.removeValidator('customValidator');
       });
 
       afterEach(function () {

--- a/test/features/validator.js
+++ b/test/features/validator.js
@@ -1,10 +1,10 @@
 define(function () {
   return function (Validator) {
     describe('Validator', function () {
-      var testParsing = function(type, input, output) {
+      var testParsing = function(type, input, output, extraOptions) {
         it('parses '+type+' requirements', function () {
           var c = new Validator({requirementType: type});
-          expect(c.parseRequirements(input)).to.eql(output);
+          expect(c.parseRequirements(input, extraOptions)).to.eql(output);
         });
       }
 
@@ -12,6 +12,14 @@ define(function () {
       testParsing('number', '4.2', [4.2]);
       testParsing('string', '42', ['42']);
       testParsing(['number', 'string'], '[4.2, 4.2]', [4.2, '4.2']);
+      testParsing({
+          '': 'number',
+          'foo': 'string',
+          'bar': 'string'
+        }, '4.2',
+        [4.2, {foo: 'FOO', bar: 'BAR'}],
+        function(value) { return value.toUpperCase(); }
+      );
     });
   };
 });

--- a/test/features/validator.js
+++ b/test/features/validator.js
@@ -1,0 +1,17 @@
+define(function () {
+  return function (Validator) {
+    describe('Validator', function () {
+      var testParsing = function(type, input, output) {
+        it('parses '+type+' requirements', function () {
+          var c = new Validator({requirementType: type});
+          expect(c.parseRequirements(input)).to.eql(output);
+        });
+      }
+
+      testParsing('integer', '42', [42]);
+      testParsing('number', '4.2', [4.2]);
+      testParsing('string', '42', ['42']);
+      testParsing(['number', 'string'], '[4.2, 4.2]', [4.2, '4.2']);
+    });
+  };
+});

--- a/test/features/validator_registry.js
+++ b/test/features/validator_registry.js
@@ -1,7 +1,7 @@
 define(function () {
-  return function (ParsleyValidator) {
-    describe('ParsleyValidator', function () {
-      var parsleyValidator = new ParsleyValidator(window.ParsleyConfig.validators || {}, window.ParsleyConfig.i18n || {});
+  return function (ParsleyValidatorRegistry) {
+    describe('ParsleyValidatorRegistry', function () {
+      var parsleyValidator = new ParsleyValidatorRegistry(window.ParsleyConfig.validators || {}, window.ParsleyConfig.i18n || {});
 
       var expectValidation = function(value, name, requirements) {
         var validator = parsleyValidator.validators[name](requirements);
@@ -9,7 +9,7 @@ define(function () {
       };
 
       it('should be a function', function () {
-        expect(ParsleyValidator).to.be.a('function');
+        expect(ParsleyValidatorRegistry).to.be.a('function');
       });
       it('should bind global config validators if given in constructor', function () {
         $.extend(true, window.ParsleyConfig, {
@@ -18,7 +18,7 @@ define(function () {
             bar: { fn: function () {}, priority: 12 }
           }
         });
-        var validator = new ParsleyValidator(window.ParsleyConfig.validators);
+        var validator = new ParsleyValidatorRegistry(window.ParsleyConfig.validators);
         expect(validator.validators).to.have.key('foo');
         expect(validator.validators).to.have.key('bar');
         expect(parsleyValidator.validators).not.to.have.key('foo');
@@ -202,7 +202,7 @@ define(function () {
         });
 
         expectWarning(function() {
-          var parsleyValidator = new ParsleyValidator(window.ParsleyConfig.validators);
+          var parsleyValidator = new ParsleyValidatorRegistry(window.ParsleyConfig.validators);
         });
         delete window.ParsleyConfig.validators.excluded;
       });

--- a/test/features/validator_registry.js
+++ b/test/features/validator_registry.js
@@ -216,6 +216,13 @@ define(function () {
           validatorRegistry.removeValidator('foo');
         });
       });
+
+      it('should provide deprecated access through ParsleyValidator for compatibility', function () {
+        window.Parsley.formatMessage('foo', 'bar');
+        expectWarning(function() {
+          window.ParsleyValidator.formatMessage('foo', 'bar');
+        });
+      });
     });
   };
 });

--- a/test/features/validator_registry.js
+++ b/test/features/validator_registry.js
@@ -179,21 +179,6 @@ define(function () {
         expect(validatorRegistry.getErrorMessage({ name: 'length', requirements: [3, 6] })).to.be('This value seems to be invalid.');
       });
 
-      if(false)
-      it('should handle parametersTransformer for custom validators', function () {
-        validatorRegistry.addValidator('foo', function (requirements) {
-          return requirements;
-        }, 32, function (requirements) {
-          return { req: requirements };
-        });
-        expect(validatorRegistry.validators.foo().requirementsTransformer).to.be.a('function');
-        validatorRegistry.updateValidator('foo', function (requirements) {
-          return requirements;
-        }, 32);
-        expect(validatorRegistry.validators.foo().requirementsTransformer).to.be(undefined);
-        validatorRegistry.removeValidator('foo');
-        expect(validatorRegistry.validators.foo).to.be(undefined);
-      });
       afterEach(function () {
         $('#element').remove();
       });

--- a/test/features/validator_registry.js
+++ b/test/features/validator_registry.js
@@ -223,6 +223,23 @@ define(function () {
           window.ParsleyValidator.formatMessage('foo', 'bar');
         });
       });
+
+      it('should provide two ways to add error messages', function () {
+        window.Parsley.addValidator('testmessage', {
+          validateString: $.noop,
+          messages: {
+            en: 'Not good at all',
+            fr: 'Très nul'
+          }
+        });
+        window.Parsley.addMessage('es', 'testmessage', 'Muy malo');
+        expect(window.Parsley.getErrorMessage({name: 'testmessage'})).to.eql('Not good at all');
+        window.Parsley.setLocale('fr');
+        expect(window.Parsley.getErrorMessage({name: 'testmessage'})).to.eql('Très nul');
+        window.Parsley.setLocale('es');
+        expect(window.Parsley.getErrorMessage({name: 'testmessage'})).to.eql('Muy malo');
+        window.Parsley.setLocale('en');
+      });
     });
   };
 });

--- a/test/tests.js
+++ b/test/tests.js
@@ -15,6 +15,7 @@ require(['config'], function () {
     // load then Parsley modules for UT
     require([
       'src/parsley',
+      'parsley/validator',
       'parsley/factory',
       'parsley/form',
       'parsley/field',
@@ -22,7 +23,7 @@ require(['config'], function () {
       'parsley/utils',
       'parsley/validator_registry',
       'i18n/fr'
-    ], function (Parsley, ParsleyFactory, ParsleyForm, ParsleyField, ParsleyUI, ParsleyUtils, ParsleyValidatorRegistry) {
+    ], function (Parsley, ParsleyValidator, ParsleyFactory, ParsleyForm, ParsleyField, ParsleyUI, ParsleyUtils, ParsleyValidatorRegistry) {
 
       // Setup console.warn so we insure it is called when we expect it
       beforeEach(function() {
@@ -45,6 +46,7 @@ require(['config'], function () {
       // load full parsley.js + UT
       require([
         'features/utils',
+        'features/validator.js',
         'features/parsley',
         'features/pubsub',
         'features/abstract',
@@ -53,7 +55,7 @@ require(['config'], function () {
         'features/form',
         'features/validator_registry',
         'features/ui'
-      ], function (utils, parsleyBase, pubsub, abstract, field, multiple, form, validator_registry, ui) {
+      ], function (utils, validator, parsleyBase, pubsub, abstract, field, multiple, form, validator_registry, ui) {
         describe('ParsleyStandard', function () {
           // Use a pristine ParsleyExtend for the standard suite:
           var previousExtend;
@@ -66,13 +68,14 @@ require(['config'], function () {
             ParsleyUtils._resetWarnings();
           });
           utils(ParsleyUtils);
+          validator(ParsleyValidator);
           parsleyBase(Parsley.Factory);
           pubsub();
           abstract();
           field(ParsleyField);
           multiple();
           form(ParsleyForm);
-          validator_registry(ParsleyValidatorRegistry);
+          validator_registry(ParsleyValidator, ParsleyValidatorRegistry);
           ui(ParsleyUI);
         });
 
@@ -106,7 +109,7 @@ require(['config'], function () {
           require([
             'features/extra'
           ], function (extra) {
-            extra(ParsleyValidatorRegistry);
+            extra(ParsleyValidator, ParsleyValidatorRegistry);
 
             // run mocha
             if (window.mochaPhantomJS)

--- a/test/tests.js
+++ b/test/tests.js
@@ -20,9 +20,9 @@ require(['config'], function () {
       'parsley/field',
       'parsley/ui',
       'parsley/utils',
-      'parsley/validator',
+      'parsley/validator_registry',
       'i18n/fr'
-    ], function (Parsley, ParsleyFactory, ParsleyForm, ParsleyField, ParsleyUI, ParsleyUtils, ParsleyValidator) {
+    ], function (Parsley, ParsleyFactory, ParsleyForm, ParsleyField, ParsleyUI, ParsleyUtils, ParsleyValidatorRegistry) {
 
       // Setup console.warn so we insure it is called when we expect it
       beforeEach(function() {
@@ -51,9 +51,9 @@ require(['config'], function () {
         'features/field',
         'features/multiple',
         'features/form',
-        'features/validator',
+        'features/validator_registry',
         'features/ui'
-      ], function (utils, parsleyBase, pubsub, abstract, field, multiple, form, validator, ui) {
+      ], function (utils, parsleyBase, pubsub, abstract, field, multiple, form, validator_registry, ui) {
         describe('ParsleyStandard', function () {
           // Use a pristine ParsleyExtend for the standard suite:
           var previousExtend;
@@ -72,7 +72,7 @@ require(['config'], function () {
           field(ParsleyField);
           multiple();
           form(ParsleyForm);
-          validator(ParsleyValidator);
+          validator_registry(ParsleyValidatorRegistry);
           ui(ParsleyUI);
         });
 
@@ -106,7 +106,7 @@ require(['config'], function () {
           require([
             'features/extra'
           ], function (extra) {
-            extra(ParsleyValidator);
+            extra(ParsleyValidatorRegistry);
 
             // run mocha
             if (window.mochaPhantomJS)

--- a/test/tests.js
+++ b/test/tests.js
@@ -79,17 +79,6 @@ require(['config'], function () {
           ui(ParsleyUI);
         });
 
-        // tested by it('should handle remote validator option') in `features/remote`
-        window.ParsleyExtend = {
-          asyncValidators: {
-            custom: {
-              fn: function (xhr) {
-                return xhr.status === 404;
-              }
-            }
-          }
-        };
-
         require([
           'features/remote',
           'features/abstract',


### PR DESCRIPTION
This branch's goal is for the `remote` plugin to become a "normal" validator. It also removes the dependency on the `validators` library.

It achieves this by allowing validators to return promises in addition to `true` and `false`.

An improved API for custom validators is proposed, with the previous API being maintained for compatibility.

The new API makes it clear if the validator is to validate multiple values (checkboxes) or single values (or both), proposes a builtin way to parse the requirements.

As I wanted to make `remote` a normal validator, I needed to provide access to extra parameters, so `validatorKind` can be an object, with keys being the different parameters and the values being the desired type. It works well, but I realized after doing this that I still needed access to the name of the field.  So I am now passing the parsley instance as the last parameter. Had I thought of that, I might not have written the more complex "extra options" parsing, but now that it's written, it could probably be helpful to others (or is it too complex for nothing?)

One thing I'm considering is to move the `addValidator`/`addMessage` to `window.Parsley`.

I must admit that, contrary to my normal habits, the commits are not perfectly atomic, but I don't have the courage to clean that up.
