### PR TITLE
Power remote

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 2.2.0-rc2
 
 - Remote: use HTTP status code for what is considered valid or not (#956)
+- Remote: add field:ajaxoptions to allow customizing of the ajax parameters (#894)
 - pattern validator is now anchored, unless it looks like /pattern/flag (#861)
 
 ## 2.2.0-rc1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 2.2.0-rc2
 
 - Remote: use HTTP status code for what is considered valid or not (#956)
+- Remote: allow RESTful urls where "{value}" is replaced by the value to validate
 - Remote: add field:ajaxoptions to allow customizing of the ajax parameters (#894)
 - pattern validator is now anchored, unless it looks like /pattern/flag (#861)
 

--- a/doc/index.html
+++ b/doc/index.html
@@ -1143,7 +1143,27 @@ window.Parsley
           </tbody>
         </table>
 
-        <h3>Methods</h3>
+        <h3 id="remote-events">Events</h3>
+        <table class="table table-stripped table-bordered">
+          <thead>
+            <tr>
+              <th class="col-md-2">Name</th>
+              <th class="col-md-1">Instance</th>
+              <th class="col-md-1">Fired by</th>
+              <th class="col-md-4">Description</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td><code>field:ajaxoptions</code> <version>#2.2</version></td>
+              <td><code>ParsleyField</code></td>
+              <td><code>whenIsValid</code> &amp; al.</td>
+              <td>Triggered just before an ajax request is sent, so one can tweak the options passed to <code>$.ajax</code>. Options are passed as a second parameter.</td>
+            </tr>
+          </tbody>
+        </table>
+
+        <h3 id="remote-methods">Methods</h3>
         <table class="table table-stripped table-bordered">
           <thead>
             <tr>

--- a/doc/index.html
+++ b/doc/index.html
@@ -1120,7 +1120,9 @@ window.Parsley
             <tr>
               <td>Remote validator</td>
               <td><code>data-parsley-remote</code> <version>#2.0</version></td>
-              <td>Define the url that will be called to validate the entered content. e.g. <code>data-parsley-remote="http://url.ext"</code></td>
+              <td>Define the url that will be called to validate the entered content. e.g. <code>data-parsley-remote="http://url.ext"</code>.
+                <br/>If the url contains the string <code>"{value}"</code>, the value will replace it in the URL (typical of RESTful APIs),
+                otherwise the value will be passed as a data parameter, with the key being the input's name or ID.</td>
             </tr>
             <tr>
               <td>Reverse</td>

--- a/src/extra/plugin/remote.js
+++ b/src/extra/plugin/remote.js
@@ -76,6 +76,8 @@ window.Parsley.addValidator('remote', {
     }, remoteOptions);
 
     // Generate store key based on ajax options
+    instance.trigger('field:ajaxoptions', instance, ajaxOptions);
+
     csr = $.param(ajaxOptions);
 
     // Initialise querry cache

--- a/src/extra/plugin/remote.js
+++ b/src/extra/plugin/remote.js
@@ -62,15 +62,21 @@ window.Parsley.addValidator('remote', {
     if ('undefined' === typeof window.Parsley.asyncValidators[validator])
       throw new Error('Calling an undefined async validator: `' + validator + '`');
 
-    // Fill data with current value
-    data[instance.$element.attr('name') || instance.$element.attr('id')] = value;
+    url = window.Parsley.asyncValidators[validator].url || url;
+
+    // Fill current value
+    if (url.indexOf('{value}') > -1) {
+      url = url.replace('{value}', encodeURIComponent(value));
+    } else {
+      data[instance.$element.attr('name') || instance.$element.attr('id')] = value;
+    }
 
     // Merge options passed in from the function with the ones in the attribute
     var remoteOptions = $.extend(true, options.options || {} , window.Parsley.asyncValidators[validator].options);
 
     // All `$.ajax(options)` could be overridden or extended directly from DOM in `data-parsley-remote-options`
     ajaxOptions = $.extend(true, {}, {
-      url: window.Parsley.asyncValidators[validator].url || url,
+      url: url,
       data: data,
       type: 'GET'
     }, remoteOptions);

--- a/src/parsley/abstract.js
+++ b/src/parsley/abstract.js
@@ -66,18 +66,18 @@ define('parsley/abstract', [
     // Trigger an event of the given name.
     // A return value of `false` interrupts the callback chain.
     // Returns false if execution was interrupted.
-    trigger: function (name, target) {
+    trigger: function (name, target, extraArg) {
       target = target || this;
       var queue = this._listeners && this._listeners[name];
       var result, parentResult;
       if (queue) {
         for(var i = queue.length; i--; ) {
-          result = queue[i].call(target, target);
+          result = queue[i].call(target, target, extraArg);
           if (result === false) return result;
         }
       }
       if (this.parent) {
-        return this.parent.trigger(name, target);
+        return this.parent.trigger(name, target, extraArg);
       }
       return true;
     },

--- a/test/features/remote.js
+++ b/test/features/remote.js
@@ -183,6 +183,24 @@ define('features/remote', [
         expect(window.Parsley._remoteCache.dummy).to.be(undefined);
       });
 
+      it('should allow the change of XHR options', function (done) {
+        var parsleyInstance =
+          $('<input id="element" data-parsley-remote="http://parsleyjs.org" name="element" value="foobar"/>')
+          .appendTo('body')
+          .parsley()
+          .on('field:ajaxoptions', function (field, options) {
+            options.url = options.url + '/test/' + options.data.element;
+          });
+
+        stubAjax(200);
+        parsleyInstance.whenValid()
+          .done(function () {
+            expect($.ajax.calledWithMatch({ url: "http://parsleyjs.org/test/foobar" })).to.be(true);
+            expect($.ajax.calledWithMatch({ data: {element: 'foobar'} })).to.be(true);
+            done();
+          });
+      });
+
       it.skip('should abort successives querries and do not handle their return');
       afterEach(function () {
         $('#element, .parsley-errors-list').remove();

--- a/test/features/remote.js
+++ b/test/features/remote.js
@@ -201,6 +201,21 @@ define('features/remote', [
           });
       });
 
+      it('should allow RESTful URLs', function (done) {
+        var parsleyInstance =
+          $('<input id="element" data-parsley-remote="http://parsleyjs.org/thisisrest/{value}" name="element" value="foo bar"/>')
+          .appendTo('body')
+          .parsley();
+
+        stubAjax(200);
+        parsleyInstance.whenValid()
+          .done(function () {
+            expect($.ajax.calledWithMatch({ url: "http://parsleyjs.org/thisisrest/foo%20bar" })).to.be(true);
+            expect($.ajax.calledWithMatch({ data: {element: 'foo bar'} })).to.be(false);
+            done();
+          });
+      });
+
       it.skip('should abort successives querries and do not handle their return');
       afterEach(function () {
         $('#element, .parsley-errors-list').remove();


### PR DESCRIPTION
This PR makes the `remote` validator much more flexible

1) Resurrect `field:ajaxoptions` event [#894]

2) Allow `{value}` in URL to be replaced by the value (instead of setting the data field). This is good for RESTful urls. This format follows RFC 6570 on URI templates.

@guillaumepotier I assume you're :+1: on these?