### PR TITLE
Fix 'jQuery Undefined' error for CommonJS environments

### DIFF
--- a/dist/parsley.js
+++ b/dist/parsley.js
@@ -1690,7 +1690,7 @@
 window.ParsleyConfig = window.ParsleyConfig || {};
 window.ParsleyConfig.i18n = window.ParsleyConfig.i18n || {};
 // Define then the messages
-window.ParsleyConfig.i18n.en = jQuery.extend(window.ParsleyConfig.i18n.en || {}, {
+window.ParsleyConfig.i18n.en = $.extend(window.ParsleyConfig.i18n.en || {}, {
   defaultMessage: "This value seems to be invalid.",
   type: {
     email:        "This value should be a valid email.",


### PR DESCRIPTION
Switch out `jQuery` for `$` in order to fix `Uncaught ReferenceError: jQuery is not defined` when loading Parsley in a CommonJS Environment