### PR TITLE
Don't trigger parsley validaton on formnovalidate buttons.

### DIFF
--- a/src/parsley/defaults.js
+++ b/src/parsley/defaults.js
@@ -16,6 +16,9 @@ define('parsley/defaults', function () {
     // Excluded inputs by default
     excluded: 'input[type=button], input[type=submit], input[type=reset], input[type=hidden]',
 
+    // Buttons that may trigger a form submit
+    submitButtons: 'input[type=submit], button[type=submit]',
+
     // Stop validating field on highest priority failing constraint
     priorityEnabled: true,
 

--- a/src/parsley/form.js
+++ b/src/parsley/form.js
@@ -18,12 +18,27 @@ define('parsley/form', [
   var statusMapping = { pending: null, resolved: true, rejected: false };
 
   ParsleyForm.prototype = {
+    onClickSetButton: function (event) {
+      var $button = $(event.target || event.srcElement);
+      $(event.target.form).data('parsleyButton', $button);
+    },
+
     onSubmitValidate: function (event) {
       var that = this;
 
       // This is a Parsley generated submit event, do not validate, do not prevent, simply exit and keep normal behavior
       if (true === event.parsley)
         return;
+
+      // Don't validate if the submit was triggered by a button with formnovalidate.
+      var $button;
+      if (!($button = this.$element.data('clicked-button'))) {
+        $button = this.$element.find(this.options.submitButtons).first();
+      }
+      this.$element.data('parsleyButton', null);
+      if (typeof $button.attr('formnovalidate') !== 'undefined') {
+        return;
+      }
 
       // Because some validations might be asynchroneous,
       // we cancel this submit and will fake it after validation.

--- a/src/parsley/ui.js
+++ b/src/parsley/ui.js
@@ -209,6 +209,8 @@ define('parsley/ui', [
 
     setupForm: function (formInstance) {
       formInstance.$element.on('submit.Parsley', false, $.proxy(formInstance.onSubmitValidate, formInstance));
+      formInstance.$element.find(formInstance.options.submitButtons)
+        .on('click.Parsley', false, $.proxy(formInstance.onClickSetButton, formInstance));
 
       // UI could be disabled
       if (false === formInstance.options.uiEnabled)

--- a/test/features/form.js
+++ b/test/features/form.js
@@ -153,6 +153,22 @@ define(function () {
         $form.submit();
         expect(callbacks.join()).to.be('validate,error,validated,validate,success,validated,submit');
       });
+      it('should not validate when triggered by a button with formnovalidate', function () {
+        var $form = $('<form id="element"><input type="string" required /><input type="submit" formnovalidate /<form>').appendTo($('body'));
+        $form.on('submit', function (e) {
+          e.preventDefault();
+        });
+
+        var callbacks = [];
+        $.each(['validate', 'error', 'success', 'validated', 'submit'], function (i, cb) {
+          $form.parsley().on('form:' + cb, function () {
+            callbacks.push(cb);
+          });
+        });
+        $form.parsley();
+        $form.find('input[type=submit]').click();
+        expect(callbacks.join()).to.be('');
+      });
       it('should fire "form:validate.parsley" to give the opportunity for changes before validation occurs', function() {
         var $form = $('<form><input type="string" required /><form>').appendTo($('body'));
         $form.parsley().on('form:validate', function () {


### PR DESCRIPTION
- Subscribe to the buttons' events and store the last clicked button.
- Check for the formnovalidate attribute in  formInstance.submit().

This implements #972 .