### PR TITLE
Fix for - only being allowed in number validator

### DIFF
--- a/src/parsley/validator_registry.js
+++ b/src/parsley/validator_registry.js
@@ -15,7 +15,7 @@ define('parsley/validator_registry', [
   var typeRegexes =  {
     email: /^((([a-z]|\d|[!#\$%&'\*\+\-\/=\?\^_`{\|}~]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])+(\.([a-z]|\d|[!#\$%&'\*\+\-\/=\?\^_`{\|}~]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])+)*)|((\x22)((((\x20|\x09)*(\x0d\x0a))?(\x20|\x09)+)?(([\x01-\x08\x0b\x0c\x0e-\x1f\x7f]|\x21|[\x23-\x5b]|[\x5d-\x7e]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])|(\\([\x01-\x09\x0b\x0c\x0d-\x7f]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF]))))*(((\x20|\x09)*(\x0d\x0a))?(\x20|\x09)+)?(\x22)))@((([a-z]|\d|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])|(([a-z]|\d|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])([a-z]|\d|-|\.|_|~|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])*([a-z]|\d|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])))\.)+(([a-z]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])|(([a-z]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])([a-z]|\d|-|\.|_|~|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])*([a-z]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])))$/i,
 
-    number: /^-?(?:\d+|\d{1,3}(?:,\d{3})+)?(?:\.\d+)?$/,
+    number: /^-?(?:(?:\d+|\d{1,3}(?:,\d{3})+)+(?:\.\d+)?|(?:\.\d+)+)$/,
 
     integer: /^-?\d+$/,
 

--- a/test/features/validator_registry.js
+++ b/test/features/validator_registry.js
@@ -75,6 +75,7 @@ define(function () {
         expect($('#element').parsley().isValid()).to.be(true);
       });
       it('should have a type="number" validator', function () {
+        expectValidation('-',         'type', 'number').not.to.be(true);
         expectValidation('foo',       'type', 'number').not.to.be(true);
         expectValidation('1',         'type', 'number').to.be(true);
         expectValidation('1.5',       'type', 'number').to.be(true);

--- a/test/features/validator_registry.js
+++ b/test/features/validator_registry.js
@@ -78,6 +78,8 @@ define(function () {
         expectValidation('-',         'type', 'number').not.to.be(true);
         expectValidation('foo',       'type', 'number').not.to.be(true);
         expectValidation('1',         'type', 'number').to.be(true);
+        expectValidation('0.5',       'type', 'number').to.be(true);
+        expectValidation('.5',       'type', 'number').to.be(true);
         expectValidation('1.5',       'type', 'number').to.be(true);
         expectValidation('-1.5',      'type', 'number').to.be(true);
         expectValidation('1,500.642', 'type', 'number').to.be(true);


### PR DESCRIPTION
Changed the number regex so that you must have at least a number with an integer part or a number with only a decimal part for a number to be valid, thus making only a number with only a - (negative sign) and invalid combination

Fixes: https://github.com/guillaumepotier/Parsley.js/issues/1008