### PR TITLE
Minor change to get rid of deprecation warning

### DIFF
--- a/src/i18n/de.js
+++ b/src/i18n/de.js
@@ -29,5 +29,5 @@ window.ParsleyConfig.i18n.de = jQuery.extend(window.ParsleyConfig.i18n.de || {},
 });
 
 // If file is loaded after Parsley main file, auto-load locale
-if ('undefined' !== typeof window.ParsleyValidator)
-  window.ParsleyValidator.addCatalog('de', window.ParsleyConfig.i18n.de, true);
+if ('undefined' !== typeof window.Parsley)
+  window.Parsley.addCatalog('de', window.ParsleyConfig.i18n.de, true);


### PR DESCRIPTION
The warning says that the method 'addCatalog' shall be invoked on Parsley instead of ParsleyValidator.