### PR TITLE
Set french locale after adding the messages

### DIFF
--- a/dist/i18n/fr.js
+++ b/dist/i18n/fr.js
@@ -24,3 +24,5 @@ window.Parsley.addMessages('fr', {
   check:          "Vous devez sélectionner entre %s et %s choix.",
   equalto:        "Cette valeur devrait être identique."
 });
+
+Parsley.setLocale('fr');

--- a/src/i18n/fr.js
+++ b/src/i18n/fr.js
@@ -24,3 +24,5 @@ window.Parsley.addMessages('fr', {
   check:          "Vous devez sélectionner entre %s et %s choix.",
   equalto:        "Cette valeur devrait être identique."
 });
+
+Parsley.setLocale('fr');


### PR DESCRIPTION
When including the french version of Parsley, the messages are not being translated because the locale is not set.