### PR TITLE
Corrected typo

### DIFF
--- a/doc/index.html
+++ b/doc/index.html
@@ -734,7 +734,7 @@ if (false === instance.options.priorityEnabled)
                 </td>
                 <td>Validates that a value matches a specific regular expression (regex).
                   <br/>Note that patterns are anchored, i.e. must match the whole string.
-                  <br/>Parsley deviates from the standard for patterns looking like <code>/<i>pattern</i>/<i>{flag}</i></code>; these are interpreted as litteral regexp and are not anchored.
+                  <br/>Parsley deviates from the standard for patterns looking like <code>/<i>pattern</i>/<i>{flag}</i></code>; these are interpreted as literal regexp and are not anchored.
                 </td>
               </tr>
               <tr>


### PR DESCRIPTION
Corrected spelling of literal from 'litteral'