### PR TITLE
Allow remoteOptions to be set from a function

### DIFF
--- a/src/parsley/remote.js
+++ b/src/parsley/remote.js
@@ -62,7 +62,13 @@ Parsley.addValidator('remote', {
     }
 
     // Merge options passed in from the function with the ones in the attribute
-    var remoteOptions = $.extend(true, options.options || {} , Parsley.asyncValidators[validator].options);
+    var remoteOptions = $.extend(
+      true,
+      options.options || {},
+      (typeof Parsley.asyncValidators[validator].options === 'function' ?
+          Parsley.asyncValidators[validator].options() :
+          Parsley.asyncValidators[validator].options)
+    );
 
     // All `$.ajax(options)` could be overridden or extended directly from DOM in `data-parsley-remote-options`
     ajaxOptions = $.extend(true, {}, {


### PR DESCRIPTION
When using asyncValidator, I found it very useful to be able to load remoteOptions dynamically - in the case where the values of other form inputs are needed to validate the target input. For example, a password validator that ensures the user's personal info (name, email, etc.) is not contained in the password.