### PR TITLE
Removing .babelrc file since Babel 6 no longer allow "blacklist" option

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,3 +1,0 @@
-{
-  "blacklist": ["useStrict"]
-}


### PR DESCRIPTION
"blacklist" is deprecated in Babel 6.

Source: http://babeljs.io/blog/2015/10/29/6.0.0#opt-in-plugins
