### PR TITLE
data-parsley-class-handler can now contain a global function name

### DIFF
--- a/doc/examples/class-handler.html
+++ b/doc/examples/class-handler.html
@@ -1,0 +1,192 @@
+
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="description" content="Parsley, the ultimate frontend javascript form validation library">
+    <meta name="author" content="Guillaume Potier">
+
+    <title>Parsley - Examples | Simple form demo</title>
+
+    <!-- Bootstrap core CSS -->
+    <link href="../../bower_components/bootstrap/dist/css/bootstrap.css" rel="stylesheet">
+
+    <!-- Custom styles for this template -->
+    <link href="../assets/docs.css" rel="stylesheet">
+
+    <!-- HTML5 shim and Respond.js IE8 support of HTML5 elements and media queries -->
+    <!--[if lt IE 9]>
+      <script src="https://oss.maxcdn.com/libs/html5shiv/3.7.0/html5shiv.js"></script>
+      <script src="https://oss.maxcdn.com/libs/respond.js/1.3.0/respond.min.js"></script>
+    <![endif]-->
+
+    <link href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/7.3/styles/github.min.css" rel="stylesheet">
+
+    <link href="../../src/parsley.css" rel="stylesheet">
+    <style class="example">
+h4 {
+  margin-bottom: 10px;
+}
+p.parsley-success {
+  color: #468847;
+  background-color: #DFF0D8;
+  border: 1px solid #D6E9C6;
+}
+p.parsley-error {
+  color: #B94A48;
+  background-color: #F2DEDE;
+  border: 1px solid #EED3D7;
+}
+    </style>
+  </head>
+
+  <body class="examples">
+
+    <div class="container">
+
+      <div class="masthead">
+        <div class="header">
+          <h3 class="text-muted"><a href="../../">Parsley</a></h3>
+
+          <span class="social-buttons inline-block">
+            <a href="https://twitter.com/share" class="twitter-share-button" data-url="http://parsleyjs.org" data-text="Parsley, the ultimate javascript form validation library. #parsleyjs" data-via="guillaumepotier" data-related="guillaumepotier" data-hashtags="parsleyjs">Tweet</a>
+            <script>!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0],p=/^http:/.test(d.location)?'http':'https';if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src=p+'://platform.twitter.com/widgets.js';fjs.parentNode.insertBefore(js,fjs);}}(document, 'script', 'twitter-wjs');</script>
+
+            <iframe src="http://ghbtns.com/github-btn.html?user=guillaumepotier&repo=Parsley.js&type=watch&count=true" allowtransparency="true" frameborder="0" scrolling="0" width="110" height="20"></iframe>
+
+            <iframe src="http://ghbtns.com/github-btn.html?user=guillaumepotier&repo=Parsley.js&type=fork&count=true" allowtransparency="true" frameborder="0" scrolling="0" width="110" height="20"></iframe>
+          </span>
+        </div>
+      </div>
+
+      <ul class="nav nav-justified">
+        <li><a href="../../">Home</a></li>
+        <li class="active"><a href="../examples.html">Examples</a></li>
+        <li><a href="../index.html">Documentation</a></li>
+        <li><a href="../download.html">Download</a></li>
+        <li><a href="../help.html">Help</a></li>
+        <li><a href="../annotated-source/main.html">Annotated&nbsp;source</a></li>
+        <li><a href="../tests.html">Tests</a></li>
+      </ul>
+
+      <div class="row">
+
+        <!-- ###################### BEGINNING OF EXAMPLE ######################-->
+
+        <div class="col-md-4">
+          <h2>Simple form example *</h2>
+          <small class="pull-left"><a href="../examples.html">&lt;&lt; Back to examples</a>
+          — <a href="#" class="play">Try it on CodePen</a>
+          </small>
+          <span class="clearfix"></span>
+          <hr></hr>
+
+<div class="form-group example">
+<div class="bs-callout bs-callout-warning hidden">
+  <h4>Oh snap!</h4>
+  <p>This form seems to be invalid :(</p>
+</div>
+
+<div class="bs-callout bs-callout-info hidden">
+  <h4>Yay!</h4>
+  <p>Everything seems to be ok :)</p>
+</div>
+
+<form id="demo-form" data-parsley-validate>
+  <label for="fullname">Full Name * :</label>
+  <input type="text" class="form-control" name="fullname" required />
+
+  <label for="email">Email * :</label>
+  <input type="email" class="form-control" name="email" data-parsley-trigger="change" required />
+
+  <label for="gender">Gender *:</label>
+  <p>
+    <label>M: <input type="radio" name="gender" id="genderM" value="M" required /></label>
+    <label>F: <input type="radio" name="gender" id="genderF" value="F" /></label>
+  </p>
+
+  <!-- Alternative 1: You can specify the class-handler as an attribute -->
+  <label for="hobbies">Hobbies (Optional, but 2 minimum):</label>
+  <p>
+    <label>Skiing <input type="checkbox" name="hobbies[]" id="hobby1" value="ski" data-parsley-mincheck="2" data-parsley-class-handler="parsleyClassHandler" /></label><br/>
+    <label>Running <input type="checkbox" name="hobbies[]" id="hobby2" value="run" data-parsley-class-handler="parsleyClassHandler" /></label><br/>
+    <label>Eating <input type="checkbox" name="hobbies[]" id="hobby3" value="eat" data-parsley-class-handler="parsleyClassHandler" /></label><br/>
+    <label>Sleeping <input type="checkbox" name="hobbies[]" id="hobby4" value="sleep" data-parsley-class-handler="parsleyClassHandler" /></label><br/>
+    <label>Reading <input type="checkbox" name="hobbies[]" id="hobby5" value="read" data-parsley-class-handler="parsleyClassHandler" /></label><br/>
+    <label>Coding <input type="checkbox" name="hobbies[]" id="hobby6" value="code" data-parsley-class-handler="parsleyClassHandler" /></label><br/>
+  </p>
+
+  <p>
+  <label for="heard">Heard about us via *:</label>
+  <select id="heard" required>
+    <option value="">Choose..</option>
+    <option value="press">Press</option>
+    <option value="net">Internet</option>
+    <option value="mouth">Word of mouth</option>
+    <option value="other">Other..</option>
+  </select>
+  </p>
+
+  <p>
+  <label for="message">Message (20 chars min, 100 max) :</label>
+  <textarea id="message" class="form-control" name="message" data-parsley-trigger="keyup" data-parsley-minlength="20" data-parsley-maxlength="100" data-parsley-minlength-message = "Come on! You need to enter at least a 20 character comment.." data-parsley-validation-threshold="10"></textarea>
+  </p>
+
+  <br/>
+  <input type="submit" class="btn btn-default" value="validate"/>
+
+  <p><small>* Please, note that this demo form is not a perfect example of UX-awareness. The aim here is to show a quick overview of parsley-API and Parsley customizable behavior.</small></p>
+</form>
+          </div>
+        </div>
+        <div class="col-md-8">
+          <div class="code-block">
+<pre><code class="example"></code></pre>
+          </div>
+        </div>
+      </div>
+
+
+      <!-- ###################### END OF EXAMPLE ######################-->
+
+      <!-- Site footer -->
+      <div class="footer">
+        <p>&copy; <a href="https://twitter.com/guillaumepotier" title="Guillaume Potier on Twitter">Guillaume Potier</a> 2014 - <a href="http://wisembly.com">@Wisembly</a></p>
+      </div>
+    </div>
+
+    <script type="text/javascript" src="../../bower_components/jquery/dist/jquery.min.js"></script>
+    <script type="text/javascript" src="../../bower_components/bootstrap/js/affix.js"></script>
+    <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/7.3/highlight.min.js"></script>
+
+    <script type="text/javascript" src="../../dist/parsley.js"></script>
+    <script type="text/javascript" class="example">
+function parsleyClassHandler(field) {
+  var parent = field.$element.closest('p');
+  if (parent.length)
+    return parent; 
+  return null; // i.e., use default logic
+}
+		
+$(function () {
+  $('#demo-form').parsley().on('field:validated', function() {
+    var ok = $('.parsley-error').length === 0;
+    $('.bs-callout-info').toggleClass('hidden', !ok);
+    $('.bs-callout-warning').toggleClass('hidden', ok);
+  })
+  .on('form:submit', function() {
+    return false; // Don't submit form for this demo
+  });
+	
+  // Alternative 2: You can specify the classHandler in the JS code
+  $('input[type=radio]').parsley({
+    classHandler: parsleyClassHandler
+  })
+});
+    </script>
+    <script type="text/javascript" src="../assets/example.js"></script>
+
+  </body>
+</html>

--- a/doc/index.html
+++ b/doc/index.html
@@ -956,12 +956,12 @@ window.Parsley
             <tr>
               <td>Class handler <version>#2.0</version></td>
               <td><code>data-parsley-class-handler="#element"</code></td>
-              <td>Specify the existing DOM container where ParsleyUI should add error and success classes. It is also possible to configure it with a callback function from javascript, see <a href="annotated-source/defaults.html">the annotated source</a>.</td>
+              <td>Specify the existing DOM container where ParsleyUI should add error and success classes. Since 2.3.12 it is also possible to configure it with a callback function from javascript, see <a href="examples/class-handler.html">the example</a>.</td>
             </tr>
             <tr>
               <td>Errors container <version>#2.0</version></td>
               <td><code>data-parsley-errors-container="#element"</code></td>
-              <td>Specify the existing DOM container where ParsleyUI should put the errors. It is also possible to configure it with a callback function from javascript, see <a href="annotated-source/defaults.html">the annotated source</a>.</td>
+              <td>Specify the existing DOM container where ParsleyUI should put the errors. Since 2.3.12 it is also possible to configure it with a callback function from javascript, see <a href="examples/class-handler.html">the example</a>.</td>
             </tr>
             <tr>
               <td>Error message <version>#2.0</version></td>

--- a/src/parsley/ui.js
+++ b/src/parsley/ui.js
@@ -296,11 +296,11 @@ ParsleyUI.Field = {
       if ($(this.options.errorsContainer).length)
         return $(this.options.errorsContainer).append(this._ui.$errorsWrapper);
       else if ('function' === typeof window[this.options.errorsContainer])
-				$errorsContainer = window[this.options.errorsContainer];
+        $errorsContainer = window[this.options.errorsContainer];
       else
         ParsleyUtils.warn('The errors container `' + this.options.errorsContainer + '` does not exist in DOM nor as a global JS function');
-    } 
-    
+    }
+
     if ('function' === typeof this.options.errorsContainer)
       $errorsContainer = this.options.errorsContainer.call(this, this);
 

--- a/src/parsley/ui.js
+++ b/src/parsley/ui.js
@@ -261,20 +261,20 @@ ParsleyUI.Field = {
       return $(this.options.classHandler);
 
     // Class handled could also be determined by function given in Parsley options
-	var $handlerFunction = this.options.classHandler;
-    
-    // It might also be the function name of a global function
-	if ('string' === typeof this.options.classHandler && 'function' === typeof window[this.options.classHandler])
-	  $handlerFunction = window[this.options.classHandler];
+    var $handlerFunction = this.options.classHandler;
 
-	if ('function' === typeof $handlerFunction)
-	{
+    // It might also be the function name of a global function
+    if ('string' === typeof this.options.classHandler && 'function' === typeof window[this.options.classHandler])
+      $handlerFunction = window[this.options.classHandler];
+
+    if ('function' === typeof $handlerFunction)
+    {
       var $handler = $handlerFunction.call(this, this);
 
       // If this function returned a valid existing DOM element, go for it
       if ('undefined' !== typeof $handler && $handler.length)
         return $handler;
-	}
+    }
 
     // Otherwise, if simple element (input, texatrea, select...) it will perfectly host the classes
     if (!this.options.multiple || this.$element.is('select'))

--- a/src/parsley/ui.js
+++ b/src/parsley/ui.js
@@ -273,7 +273,7 @@ ParsleyUI.Field = {
       // If this function returned a valid existing DOM element, go for it
       if ('undefined' !== typeof $handler && $handler.length)
         return $handler;
-    } else if ('object' === typeof $handlerFunction && $handlerFunction instanceOf jQuery && $handlerFunction.length) {
+    } else if ('object' === typeof $handlerFunction && $handlerFunction instanceof jQuery && $handlerFunction.length) {
       return $handlerFunction;
     } else if ($handlerFunction) {
       ParsleyUtils.warn('The class handler `' + $handlerFunction + '` does not exist in DOM nor as a global JS function');

--- a/src/parsley/ui.js
+++ b/src/parsley/ui.js
@@ -286,23 +286,23 @@ ParsleyUI.Field = {
   },
 
   _insertErrorWrapper: function () {
-    var $errorsContainer;
+    var $errorsContainer = this.options.errorsContainer;
 
     // Nothing to do if already inserted
     if (0 !== this._ui.$errorsWrapper.parent().length)
       return this._ui.$errorsWrapper.parent();
 
-    if ('string' === typeof this.options.errorsContainer) {
-      if ($(this.options.errorsContainer).length)
-        return $(this.options.errorsContainer).append(this._ui.$errorsWrapper);
-      else if ('function' === typeof window[this.options.errorsContainer])
-        $errorsContainer = window[this.options.errorsContainer];
+    if ('string' === typeof $errorsContainer) {
+      if ($($errorsContainer).length)
+        return $($errorsContainer).append(this._ui.$errorsWrapper);
+      else if ('function' === typeof window[$errorsContainer])
+        $errorsContainer = window[$errorsContainer];
       else
-        ParsleyUtils.warn('The errors container `' + this.options.errorsContainer + '` does not exist in DOM nor as a global JS function');
+        ParsleyUtils.warn('The errors container `' + $errorsContainer + '` does not exist in DOM nor as a global JS function');
     }
 
-    if ('function' === typeof this.options.errorsContainer)
-      $errorsContainer = this.options.errorsContainer.call(this, this);
+    if ('function' === typeof $errorsContainer)
+      $errorsContainer = $errorsContainer.call(this, this);
 
     if ('undefined' !== typeof $errorsContainer && $errorsContainer.length)
       return $errorsContainer.append(this._ui.$errorsWrapper);

--- a/src/parsley/ui.js
+++ b/src/parsley/ui.js
@@ -259,7 +259,7 @@ ParsleyUI.Field = {
     // An element selector could be passed through DOM with `data-parsley-class-handler=#foo`
     if ('string' === typeof this.options.classHandler && $(this.options.classHandler).length)
       return $(this.options.classHandler);
-    
+
     // Class handled could also be determined by function given in Parsley options
 	var $handlerFunction = this.options.classHandler;
     

--- a/src/parsley/ui.js
+++ b/src/parsley/ui.js
@@ -273,6 +273,8 @@ ParsleyUI.Field = {
       // If this function returned a valid existing DOM element, go for it
       if ('undefined' !== typeof $handler && $handler.length)
         return $handler;
+    } else if ('object' === typeof $handlerFunction && $handlerFunction instanceOf jQuery && $handlerFunction.length) {
+      return $handlerFunction;
     } else if ($handlerFunction) {
       ParsleyUtils.warn('The class handler `' + $handlerFunction + '` does not exist in DOM nor as a global JS function');
     }
@@ -304,7 +306,7 @@ ParsleyUI.Field = {
     if ('function' === typeof $errorsContainer)
       $errorsContainer = $errorsContainer.call(this, this);
 
-    if ('undefined' !== typeof $errorsContainer && $errorsContainer.length)
+    if ('object' === typeof $errorsContainer && $errorsContainer.length)
       return $errorsContainer.append(this._ui.$errorsWrapper);
 
     var $from = this.$element;

--- a/src/parsley/ui.js
+++ b/src/parsley/ui.js
@@ -273,6 +273,8 @@ ParsleyUI.Field = {
       // If this function returned a valid existing DOM element, go for it
       if ('undefined' !== typeof $handler && $handler.length)
         return $handler;
+    } else if ($handlerFunction) {
+      ParsleyUtils.warn('The class handler `' + $handlerFunction + '` does not exist in DOM nor as a global JS function');
     }
 
     // Otherwise, if simple element (input, texatrea, select...) it will perfectly host the classes
@@ -293,8 +295,10 @@ ParsleyUI.Field = {
     if ('string' === typeof this.options.errorsContainer) {
       if ($(this.options.errorsContainer).length)
         return $(this.options.errorsContainer).append(this._ui.$errorsWrapper);
+      else if ('function' === typeof window[this.options.errorsContainer])
+				return window[this.options.errorsContainer].append(this._ui.$errorsWrapper);
       else
-        ParsleyUtils.warn('The errors container `' + this.options.errorsContainer + '` does not exist in DOM');
+        ParsleyUtils.warn('The errors container `' + this.options.errorsContainer + '` does not exist in DOM nor as a global JS function');
     } else if ('function' === typeof this.options.errorsContainer)
       $errorsContainer = this.options.errorsContainer.call(this, this);
 

--- a/src/parsley/ui.js
+++ b/src/parsley/ui.js
@@ -267,8 +267,7 @@ ParsleyUI.Field = {
     if ('string' === typeof this.options.classHandler && 'function' === typeof window[this.options.classHandler])
       $handlerFunction = window[this.options.classHandler];
 
-    if ('function' === typeof $handlerFunction)
-    {
+    if ('function' === typeof $handlerFunction) {
       var $handler = $handlerFunction.call(this, this);
 
       // If this function returned a valid existing DOM element, go for it

--- a/src/parsley/ui.js
+++ b/src/parsley/ui.js
@@ -296,10 +296,12 @@ ParsleyUI.Field = {
       if ($(this.options.errorsContainer).length)
         return $(this.options.errorsContainer).append(this._ui.$errorsWrapper);
       else if ('function' === typeof window[this.options.errorsContainer])
-				return window[this.options.errorsContainer].append(this._ui.$errorsWrapper);
+				$errorsContainer = window[this.options.errorsContainer];
       else
         ParsleyUtils.warn('The errors container `' + this.options.errorsContainer + '` does not exist in DOM nor as a global JS function');
-    } else if ('function' === typeof this.options.errorsContainer)
+    } 
+    
+    if ('function' === typeof this.options.errorsContainer)
       $errorsContainer = this.options.errorsContainer.call(this, this);
 
     if ('undefined' !== typeof $errorsContainer && $errorsContainer.length)

--- a/src/parsley/ui.js
+++ b/src/parsley/ui.js
@@ -259,13 +259,22 @@ ParsleyUI.Field = {
     // An element selector could be passed through DOM with `data-parsley-class-handler=#foo`
     if ('string' === typeof this.options.classHandler && $(this.options.classHandler).length)
       return $(this.options.classHandler);
-
+    
     // Class handled could also be determined by function given in Parsley options
-    var $handler = this.options.classHandler.call(this, this);
+	var $handlerFunction = this.options.classHandler;
+    
+    // It might also be the function name of a global function
+	if ('string' === typeof this.options.classHandler && 'function' === typeof window[this.options.classHandler])
+	  $handlerFunction = window[this.options.classHandler];
 
-    // If this function returned a valid existing DOM element, go for it
-    if ('undefined' !== typeof $handler && $handler.length)
-      return $handler;
+	if ('function' === typeof $handlerFunction)
+	{
+      var $handler = $handlerFunction.call(this, this);
+
+      // If this function returned a valid existing DOM element, go for it
+      if ('undefined' !== typeof $handler && $handler.length)
+        return $handler;
+	}
 
     // Otherwise, if simple element (input, texatrea, select...) it will perfectly host the classes
     if (!this.options.multiple || this.$element.is('select'))

--- a/test/unit/ui.js
+++ b/test/unit/ui.js
@@ -137,7 +137,6 @@ describe('ParsleyUI', () => {
       }
     }).validate();
     expect($('#field3').hasClass('parsley-error')).to.be(true);
-    delete window.parsleyClassHandler;
   });
   it('should handle class-handler option with a function', () => {
     $('body').append(

--- a/test/unit/ui.js
+++ b/test/unit/ui.js
@@ -104,22 +104,10 @@ describe('ParsleyUI', () => {
         '<input id="field1" type="email" data-parsley-class-handler="#field2" required />'  +
         '<div id="field2"></div>'                                                           +
         '<div id="field3"></div>'                                                           +
-        '<div id="field4"></div>'                                                           +
       '</form>');
     $('#element').psly().validate();
     expect($('#field2').hasClass('parsley-error')).to.be(true);
     $('#element').psly().destroy();
-    $('#field1').attr('data-parsley-class-handler', 'parsleyClassHandler');
-    window.parsleyClassHandler = function (ins) {
-      expect(ins).to.be($('#field1').parsley());
-      expect(this).to.be($('#field1').parsley());
-      return $('#field4');
-    };
-    $('#element').psly().validate();
-    expect($('#field4').hasClass('parsley-error')).to.be(true);
-    $('#field1').attr('data-parsley-class-handler', 'someUndefinedFunctionName');
-    $('#element').psly().validate();
-    expect($('#field1').hasClass('parsley-error')).to.be(true);
     $('#field1').removeAttr('data-parsley-class-handler');
     $('#element').psly({
       classHandler: function (ins) {
@@ -129,6 +117,27 @@ describe('ParsleyUI', () => {
       }
     }).validate();
     expect($('#field3').hasClass('parsley-error')).to.be(true);
+    delete window.parsleyClassHandler;
+  });
+  it('should handle class-handler option with a function', () => {
+    $('body').append(
+      '<form id="element">'                                                                 +
+        '<input id="field1" type="email" data-parsley-class-handler="#field2" required />'  +
+        '<div id="field4"></div>'                                                           +
+      '</form>');
+    $('#field1').attr('data-parsley-class-handler', 'parsleyClassHandler');
+    window.parsleyClassHandler = function (ins) {
+      expect(ins).to.be($('#field1').parsley());
+      expect(this).to.be($('#field1').parsley());
+      return $('#field4');
+    };
+    $('#element').psly().validate();
+    expect($('#field4').hasClass('parsley-error')).to.be(true);
+    $('#element').psly().destroy();
+    $('#field1').attr('data-parsley-class-handler', 'someUndefinedFunctionName');
+    $('#element').psly().validate();
+    expect($('#field1').hasClass('parsley-error')).to.be(true);
+    delete window.parsleyClassHandler;
   });
   it('should show higher priority error message by default', () => {
     $('body').append('<input type="email" id="element" required />');

--- a/test/unit/ui.js
+++ b/test/unit/ui.js
@@ -116,7 +116,7 @@ describe('ParsleyUI', () => {
       return $('#field4');
     };
     $('#element').psly().validate();
-    expect($('#field4').hasClass('parsley-error')).to.be(false);
+    expect($('#field4').hasClass('parsley-error')).to.be(true);
     $('#field1').attr('data-parsley-class-handler', 'someUndefinedFunctionName');
     $('#element').psly().validate();
     expect($('#field1').hasClass('parsley-error')).to.be(true);

--- a/test/unit/ui.js
+++ b/test/unit/ui.js
@@ -50,10 +50,6 @@ describe('ParsleyUI', () => {
     };
     $('#element').psly().validate();
     expect($('#container .parsley-errors-list').length).to.be(1);
-    $('#element').psly().destroy();
-    $('#field1').removeAttr('data-parsley-errors-container');
-    $('#element').psly().validate();
-    expect($('#container2 .parsley-errors-list').length).to.be(1);
     delete window.parsleyContainerFunction;
   });
   it('should handle wrong errors-container option', () => {
@@ -154,7 +150,9 @@ describe('ParsleyUI', () => {
     expect($('#field4').hasClass('parsley-error')).to.be(true);
     $('#element').psly().destroy();
     $('#field1').attr('data-parsley-class-handler', 'someUndefinedFunctionName');
-    $('#element').psly().validate();
+    expectWarning(() => {
+      $('#element').psly().validate();
+    });
     expect($('#field1').hasClass('parsley-error')).to.be(true);
     delete window.parsleyClassHandler;
   });

--- a/test/unit/ui.js
+++ b/test/unit/ui.js
@@ -104,10 +104,23 @@ describe('ParsleyUI', () => {
         '<input id="field1" type="email" data-parsley-class-handler="#field2" required />'  +
         '<div id="field2"></div>'                                                           +
         '<div id="field3"></div>'                                                           +
+        '<div id="field4"></div>'                                                           +
+        '<div id="field5"></div>'                                                           +
       '</form>');
     $('#element').psly().validate();
     expect($('#field2').hasClass('parsley-error')).to.be(true);
     $('#element').psly().destroy();
+    $('#field1').attr('data-parsley-class-handler', 'parsleyClassHandler');
+    window.parsleyClassHandler = function (ins) {
+      expect(ins).to.be($('#field1').parsley());
+      expect(this).to.be($('#field1').parsley());
+      return $('#field4');
+    };
+    $('#element').psly().validate();
+    expect($('#field4').hasClass('parsley-error')).to.be(true);    
+    $('#field1').attr('data-parsley-class-handler', 'someUndefinedFunctionName');
+    $('#element').psly().validate();
+    expect($('#field1').hasClass('parsley-error')).to.be(true);    
     $('#field1').removeAttr('data-parsley-class-handler');
     $('#element').psly({
       classHandler: function (ins) {

--- a/test/unit/ui.js
+++ b/test/unit/ui.js
@@ -116,10 +116,10 @@ describe('ParsleyUI', () => {
       return $('#field4');
     };
     $('#element').psly().validate();
-    expect($('#field4').hasClass('parsley-error')).to.be(true);    
+    expect($('#field4').hasClass('parsley-error')).to.be(false);
     $('#field1').attr('data-parsley-class-handler', 'someUndefinedFunctionName');
     $('#element').psly().validate();
-    expect($('#field1').hasClass('parsley-error')).to.be(true);    
+    expect($('#field1').hasClass('parsley-error')).to.be(true);
     $('#field1').removeAttr('data-parsley-class-handler');
     $('#element').psly({
       classHandler: function (ins) {

--- a/test/unit/ui.js
+++ b/test/unit/ui.js
@@ -36,6 +36,26 @@ describe('ParsleyUI', () => {
     }).validate();
     expect($('#container2 .parsley-errors-list').length).to.be(1);
   });
+  it('should handle errors-container option with function', () => {
+    $('body').append(
+      '<form id="element">'                                                                                    +
+        '<input id="field1" type="text" required data-parsley-errors-container="parsleyContainerFunction" />'  +
+        '<div id="container"></div>'                                                                           +
+        '<div id="container2"></div>'                                                                          +
+      '</form>');
+    window.parsleyContainerFunction = function (ins) {
+      expect(ins).to.be($('#field1').psly());
+      expect(this).to.be($('#field1').psly());
+      return $('#container2');
+    };
+    $('#element').psly().validate();
+    expect($('#container .parsley-errors-list').length).to.be(1);
+    $('#element').psly().destroy();
+    $('#field1').removeAttr('data-parsley-errors-container');
+    $('#element').psly().validate();
+    expect($('#container2 .parsley-errors-list').length).to.be(1);
+    delete window.parsleyContainerFunction;
+  });
   it('should handle wrong errors-container option', () => {
     $('body').append('<input type="text" id="element" data-parsley-errors-container="#donotexist" required/>');
     var parsley = $('#element').psly();

--- a/test/unit/ui.js
+++ b/test/unit/ui.js
@@ -105,7 +105,6 @@ describe('ParsleyUI', () => {
         '<div id="field2"></div>'                                                           +
         '<div id="field3"></div>'                                                           +
         '<div id="field4"></div>'                                                           +
-        '<div id="field5"></div>'                                                           +
       '</form>');
     $('#element').psly().validate();
     expect($('#field2').hasClass('parsley-error')).to.be(true);


### PR DESCRIPTION
Currently, the class handler function can only be specified as JS code:

``` js
$('#element').psly({
      classHandler: function (field) {
        return $('#field3');
      }
});
```

With this minor addition, global functions can be named in the data-attribute:

``` js
function parsleyClassHandler(field) {
        return $('#field3');
}
```

``` html
<input type="text" data-parsley-class-handler="parsleyClassHandler" required />
```

(Sorry I feel quite at loss using gulp etc. I probably need to execute the build somehow and let the test suite run, could you please add this to your CONTRIBUTING.md?)
