### PR TITLE
Add field-level validation debouncing

### DIFF
--- a/doc/index.html
+++ b/doc/index.html
@@ -433,6 +433,10 @@ if (false === instance.options.priorityEnabled)
                 <td><code>data-parsley-excluded</code> <version>#2.1</version></td>
                 <td>If set to <code>true</code>, Parsley will ignore this field when binding a form.</td>
               </tr>
+              <tr>
+                <td><code>data-parsley-debounce</code> <version>#2.3</version></td>
+                <td>Postpones validation for a given number of milliseconds after user input has stopped arriving, eg: <code>data-parsley-debounce="500"</code>. Useful for expensive validations (such as remotes) that you don't want to run on every keystroke.</td>
+              </tr>
             </tbody>
           </table>
 

--- a/src/parsley/field.js
+++ b/src/parsley/field.js
@@ -16,6 +16,13 @@ var ParsleyField = function (field, domOptions, options, parsleyFormInstance) {
   this.options = options;
   this.domOptions = domOptions;
 
+  var that = this;
+  if (this.options.debounce) {
+    this.debouncedValidate = ParsleyUtils.debounce(function () {
+      return that.validate();
+    }, this.options.debounce);
+  }
+
   // Initialize some properties
   this.constraints = [];
   this.constraintsByName = {};

--- a/src/parsley/ui.js
+++ b/src/parsley/ui.js
@@ -307,7 +307,7 @@ ParsleyUI.Field = {
     $toBind.off('.Parsley');
     if (this._failedOnce)
       $toBind.on(ParsleyUtils.namespaceEvents(this.options.triggerAfterFailure, 'Parsley'), () => {
-        this.validate();
+        this.options.debounce ? this.debouncedValidate() : this.validate();
       });
     else if (trigger = ParsleyUtils.namespaceEvents(this.options.trigger, 'Parsley')) {
       $toBind.on(trigger, event => {
@@ -324,7 +324,7 @@ ParsleyUI.Field = {
       if (!(this._ui && this._ui.validationInformationVisible) && this.getValue().length <= this.options.validationThreshold)
         return;
 
-    this.validate();
+    this.options.debounce ? this.debouncedValidate() : this.validate();
   },
 
   _resetUI: function () {

--- a/src/parsley/utils.js
+++ b/src/parsley/utils.js
@@ -124,7 +124,49 @@ var ParsleyUtils = {
       Object.prototype = null;
       return result;
     };
-  })()
+  })(),
+
+  // http://underscorejs.org/#now
+  now: Date.now || function () {
+    return new Date().getTime();
+  },
+
+  // http://underscorejs.org/#debounce
+  debounce: function (func, wait, immediate) {
+    var timeout;
+    var args;
+    var context;
+    var timestamp;
+    var result;
+
+    var later = function () {
+      var last = ParsleyUtils.now() - timestamp;
+
+      if (last < wait && last >= 0) {
+        timeout = setTimeout(later, wait - last);
+      } else {
+        timeout = null;
+        if (!immediate) {
+          result = func.apply(context, args);
+          if (!timeout) context = args = null;
+        }
+      }
+    };
+
+    return function () {
+      context = this;
+      args = arguments;
+      timestamp = ParsleyUtils.now();
+      var callNow = immediate && !timeout;
+      if (!timeout) timeout = setTimeout(later, wait);
+      if (callNow) {
+        result = func.apply(context, args);
+        context = args = null;
+      }
+
+      return result;
+    };
+  }
 };
 
 export default ParsleyUtils;

--- a/test/unit/field.js
+++ b/test/unit/field.js
@@ -348,6 +348,34 @@ describe('ParsleyField', () => {
       expect($('#element').parsley().getValue()).to.be('foo');
     });
   });
+
+  var debounceCount = 0;
+  var debounceWait = 500;
+  it('should not have executed the debounced yet', () => {
+    // create a custom validator to test debouncing
+    var count = 0;
+    Parsley.addValidator('debounceTest', {
+      requirementType: 'string',
+      validateString: function(value, requirement) {
+        debounceCount++;
+      }
+    });
+    $('body').append('<input type="email" data-parsley-debounce="' + debounceWait + '" data-parsley-debounce-test="true" data-parsley-trigger="keyup" id="element" value="foobar@example.com" />');
+    $('#element').psly();
+    // keystrokes in a short timespan shouldn't trigger validation yet
+    $('#element').trigger($.Event('keyup')).trigger($.Event('keyup')).trigger($.Event('keyup'));
+    expect(count).to.be.eql(0);
+    // now pause to give time for the debounced function to execute
+    var date = new Date();
+    var curDate = null;
+    do { curDate = new Date(); } while (curDate-date < debounceWait + 50);
+  });
+  // needs to be a separate assertion in order for the thread to relinquish
+  // control to the debounced timeout resolution
+  it('should have executed the debounced by now', () => {
+      expect(debounceCount).to.be.eql(1);
+  });
+
   it('should inherit options from the form, even if the form is bound after', () => {
     $('body').append('<form id="element" data-parsley-required>' +
       '<input type="text"/></form>');


### PR DESCRIPTION
For remotes and other expensive validations, I wanted to be able to [debounce](http://underscorejs.org/#debounce) the validation call during user input. This works by using a debounced version of `ParsleyField.validate()` when the `data-parsley-debounce` option is specified.