### PR TITLE
Defined dependencies for jspm

### DIFF
--- a/package.json
+++ b/package.json
@@ -86,6 +86,12 @@
       "expectWarning"
     ]
   },
+  "jspm": {
+    "main": "dist/parsley.js",
+    "dependencies": {
+      "jquery": "npm:jquery"
+    }
+  },
   "spm": {
     "main": "dist/parsley.js",
     "ignore": [


### PR DESCRIPTION
JSPM needs the dependencies defined in a particular format. If this is not done one would need to define the dependencies manually. Also by not defining a jQuery version jspm will use the version that is currently being used in the said project.
