### PR TITLE
Adds isodatetype for input type=date support

### DIFF
--- a/src/parsley/field.js
+++ b/src/parsley/field.js
@@ -271,15 +271,15 @@ ParsleyField.prototype = {
 
     // range
     if ('undefined' !== typeof this.$element.attr('min') && 'undefined' !== typeof this.$element.attr('max'))
-      this.addConstraint('range', [this.$element.attr('min'), this.$element.attr('max')], undefined, true);
+      this.addConstraint(this.$element.attr('type') == 'date' ? 'isodaterange' : 'range', [this.$element.attr('min'), this.$element.attr('max')], undefined, true);
 
     // HTML5 min
     else if ('undefined' !== typeof this.$element.attr('min'))
-      this.addConstraint('min', this.$element.attr('min'), undefined, true);
+      this.addConstraint(this.$element.attr('type') == 'date' ? 'isodatemin' : 'min', this.$element.attr('min'), undefined, true);
 
     // HTML5 max
     else if ('undefined' !== typeof this.$element.attr('max'))
-      this.addConstraint('max', this.$element.attr('max'), undefined, true);
+      this.addConstraint(this.$element.attr('type') == 'date' ? 'isodatemax' : 'max', this.$element.attr('max'), undefined, true);
 
 
     // length

--- a/src/parsley/validator.js
+++ b/src/parsley/validator.js
@@ -27,6 +27,12 @@ var requirementConverters = {
   object: function(string) {
     return ParsleyUtils.deserializeValue(string);
   },
+  isodate: function(string) {
+    var parts = string.match(/^(\d{4})-(\d\d)-(\d\d)$/);
+    if (!parts)
+      throw 'Invalid isodate: "' + string + '"';
+    return string;
+  },
   regexp: function(regexp) {
     var flags = '';
 

--- a/src/parsley/validator_registry.js
+++ b/src/parsley/validator_registry.js
@@ -57,7 +57,9 @@ var typeRegexes =  {
         // resource path
         "(?:/\\S*)?" +
       "$", 'i'
-    )
+    ),
+
+  isodate: /^(\d{4})\D?(0[1-9]|1[0-2])\D?([12]\d|0[1-9]|3[01])$/
 };
 typeRegexes.range = typeRegexes.number;
 
@@ -329,6 +331,27 @@ ParsleyValidatorRegistry.prototype = {
         return value >= min && value <= max;
       },
       requirementType: ['number', 'number'],
+      priority: 30
+    },
+    isodaterange: {
+      validateString: function (value, min, max) {
+        return value >= min && value <= max;
+      },
+      requirementType: ['isodate', 'isodate'],
+      priority: 30
+    },
+    isodatemin: {
+      validateString: function (value, min) {
+        return value >= min;
+      },
+      requirementType: 'isodate',
+      priority: 30
+    },
+    isodatemax: {
+      validateString: function (value, max) {
+        return value <= max;
+      },
+      requirementType: 'isodate',
       priority: 30
     },
     equalto: {

--- a/test/unit/validator.js
+++ b/test/unit/validator.js
@@ -11,6 +11,7 @@ describe('Validator', () => {
   testParsing('integer', '42', [42]);
   testParsing('number', '4.2', [4.2]);
   testParsing('string', '42', ['42']);
+  testParsing('isodate', '2016-08-05', ['2016-08-05']);
   testParsing(['number', 'string'], '[4.2, 4.2]', [4.2, '4.2']);
   testParsing({
       '': 'number',

--- a/test/unit/validator_registry.js
+++ b/test/unit/validator_registry.js
@@ -70,6 +70,7 @@ describe('ParsleyValidatorRegistry', () => {
     expectValidation('17',  'max', 10).not.to.be(true);
     $('body').append('<input type="text" id="element" value="7" max="20" />');
     expect($('#element').parsley().isValid()).to.be(true);
+
   });
   it('should have a range validator', () => {
     expectValidation('1',  'range', [5, 10]).not.to.be(true);
@@ -81,6 +82,37 @@ describe('ParsleyValidatorRegistry', () => {
     $('#element').remove();
     $('body').append('<input type="range" id="element" value="7" max="20" min="2" />');
     expect($('#element').parsley().isValid()).to.be(true);
+  });
+  it('should have a isodaterange validator', () => {
+    expectValidation('2016-08-02',  'isodaterange', ['2016-05-01', '2016-08-01']).not.to.be(true);
+    expectValidation('2016-08-01',  'isodaterange', ['2016-05-01', '2016-08-01']).to.be(true);
+    $('#element').remove();
+    $('body').append('<input type="date" id="element" value="2016-08-05" min="2016-08-01" max="2016-08-06" />');
+    expect($('#element').parsley().isValid()).to.be(true);
+
+    $('#element').remove();
+    $('body').append('<input type="date" id="element" value="2016-08-08" min="2016-08-01" max="2016-08-06" />');
+    expect($('#element').parsley().isValid()).to.be(false);
+  });
+  it('should have a isodatemin validator', () => {
+    expectValidation('2016-08-01',  'isodatemin', '2016-08-02').not.to.be(true);
+    expectValidation('2016-08-02',  'isodatemin', '2016-08-02').to.be(true);
+    $('body').append('<input type="date" id="element" value="2016-08-01" min="2016-08-01" />');
+    expect($('#element').parsley().isValid()).to.be(true);
+
+    $('#element').remove();
+    $('body').append('<input type="date" id="element" value="2016-08-01" min="2016-08-02" />');
+    expect($('#element').parsley().isValid()).to.be(false);
+  });
+  it('should have a isodatemax validator', () => {
+    expectValidation('2016-08-01',  'isodatemax', '2016-08-01').to.be(true);
+    expectValidation('2016-08-02',  'isodatemax', '2016-08-01').not.to.be(true);
+    $('body').append('<input type="date" id="element" value="2016-08-01" max="2016-08-01" />');
+    expect($('#element').parsley().isValid()).to.be(true);
+
+    $('#element').remove();
+    $('body').append('<input type="date" id="element" value="2016-08-02" max="2016-08-01" />');
+    expect($('#element').parsley().isValid()).to.be(false);
   });
   it('should have a type="number" validator', () => {
     expectValidation('foo',       'type', 'number').not.to.be(true);
@@ -123,6 +155,10 @@ describe('ParsleyValidatorRegistry', () => {
     expectValidation('http://www.foo.bar',         'type', 'url').to.be(true);
     expectValidation('https://www.foo.bar',        'type', 'url').to.be(true);
     expectValidation('http://192.168.1.1/foo/bar', 'type', 'url').to.be(true);
+  });
+  it('should have a type="isodate" validator', () => {
+    expectValidation('2016-08-31',  'type', 'isodate').to.be(true);
+    expectValidation('2016-8-31',   'type', 'isodate').not.to.be(true);
   });
   it('should have a pattern validator', () => {
     expectValidation('a', 'pattern','[a-z]+'   ).to.be(true);


### PR DESCRIPTION
Parsleyjs fails when trying to use a html5 input type=date with min and/or max. This pull request adds support for such types by adding an 'isodate' type and implementing min, max and range constraints.

I avoided the already present extra 'dateiso' type because I didn't want to conflict with something that already exists, and I think this should be working natively without the user needing to add any components or custom validators.

I think this should also fix issue #814 

The error reported will now be the defaultMessage (This value seems to be invalid.)'. Ideally I would use the standard min,max and range errors, but then I'd run into locale issues on properly formatting the date in the response. So I'm not sure how to deal with that yet, but as 'input type=date min/max=...' is currently completely broken anyway, this is still an improvement.
