### PR TITLE
Added 'type' attribute check on range/min/max validator

### DIFF
--- a/doc/annotated-source/field.html
+++ b/doc/annotated-source/field.html
@@ -804,8 +804,8 @@ Bind specific HTML5 constraints to be HTML5 compliant</p>
               <p>range</p>
 
             </div>
-            
-            <div class="content"><div class='highlight'><pre>    <span class="hljs-keyword">if</span> (<span class="hljs-string">'undefined'</span> !== <span class="hljs-keyword">typeof</span> <span class="hljs-keyword">this</span>.$element.attr(<span class="hljs-string">'min'</span>) &amp;&amp; <span class="hljs-string">'undefined'</span> !== <span class="hljs-keyword">typeof</span> <span class="hljs-keyword">this</span>.$element.attr(<span class="hljs-string">'max'</span>))
+
+            <div class="content"><div class='highlight'><pre>    <span class="hljs-keyword">if</span> (<span class="hljs-keyword">this</span>.$element.attr(<span class="hljs-string">'type'</span>) !== 'date' &amp;&amp; <span class="hljs-string">'undefined'</span> !== <span class="hljs-keyword">typeof</span> <span class="hljs-keyword">this</span>.$element.attr(<span class="hljs-string">'min'</span>) &amp;&amp; <span class="hljs-string">'undefined'</span> !== <span class="hljs-keyword">typeof</span> <span class="hljs-keyword">this</span>.$element.attr(<span class="hljs-string">'max'</span>))
       <span class="hljs-keyword">this</span>.addConstraint(<span class="hljs-string">'range'</span>, [<span class="hljs-keyword">this</span>.$element.attr(<span class="hljs-string">'min'</span>), <span class="hljs-keyword">this</span>.$element.attr(<span class="hljs-string">'max'</span>)], <span class="hljs-literal">undefined</span>, <span class="hljs-literal">true</span>);</pre></div></div>
             
         </li>
@@ -820,8 +820,8 @@ Bind specific HTML5 constraints to be HTML5 compliant</p>
               <p>HTML5 min</p>
 
             </div>
-            
-            <div class="content"><div class='highlight'><pre>    <span class="hljs-keyword">else</span> <span class="hljs-keyword">if</span> (<span class="hljs-string">'undefined'</span> !== <span class="hljs-keyword">typeof</span> <span class="hljs-keyword">this</span>.$element.attr(<span class="hljs-string">'min'</span>))
+
+            <div class="content"><div class='highlight'><pre>    <span class="hljs-keyword">else</span> <span class="hljs-keyword">if</span> (<span class="hljs-keyword">this</span>.$element.attr(<span class="hljs-string">'type'</span>) !== 'date' &amp;&amp; <span class="hljs-string">'undefined'</span> !== <span class="hljs-keyword">typeof</span> <span class="hljs-keyword">this</span>.$element.attr(<span class="hljs-string">'min'</span>))
       <span class="hljs-keyword">this</span>.addConstraint(<span class="hljs-string">'min'</span>, <span class="hljs-keyword">this</span>.$element.attr(<span class="hljs-string">'min'</span>), <span class="hljs-literal">undefined</span>, <span class="hljs-literal">true</span>);</pre></div></div>
             
         </li>
@@ -836,8 +836,8 @@ Bind specific HTML5 constraints to be HTML5 compliant</p>
               <p>HTML5 max</p>
 
             </div>
-            
-            <div class="content"><div class='highlight'><pre>    <span class="hljs-keyword">else</span> <span class="hljs-keyword">if</span> (<span class="hljs-string">'undefined'</span> !== <span class="hljs-keyword">typeof</span> <span class="hljs-keyword">this</span>.$element.attr(<span class="hljs-string">'max'</span>))
+
+            <div class="content"><div class='highlight'><pre>    <span class="hljs-keyword">else</span> <span class="hljs-keyword">if</span> (<span class="hljs-keyword">this</span>.$element.attr(<span class="hljs-string">'type'</span>) !== 'date' &amp;&amp; <span class="hljs-string">'undefined'</span> !== <span class="hljs-keyword">typeof</span> <span class="hljs-keyword">this</span>.$element.attr(<span class="hljs-string">'max'</span>))
       <span class="hljs-keyword">this</span>.addConstraint(<span class="hljs-string">'max'</span>, <span class="hljs-keyword">this</span>.$element.attr(<span class="hljs-string">'max'</span>), <span class="hljs-literal">undefined</span>, <span class="hljs-literal">true</span>);</pre></div></div>
             
         </li>

--- a/src/parsley/field.js
+++ b/src/parsley/field.js
@@ -270,15 +270,15 @@ ParsleyField.prototype = {
       this.addConstraint('pattern', this.$element.attr('pattern'), undefined, true);
 
     // range
-    if ('undefined' !== typeof this.$element.attr('min') && 'undefined' !== typeof this.$element.attr('max'))
+    if (this.$element.attr('type') !== 'date' && 'undefined' !== typeof this.$element.attr('min') && 'undefined' !== typeof this.$element.attr('max'))
       this.addConstraint('range', [this.$element.attr('min'), this.$element.attr('max')], undefined, true);
 
     // HTML5 min
-    else if ('undefined' !== typeof this.$element.attr('min'))
+    else if (this.$element.attr('type') !== 'date' && 'undefined' !== typeof this.$element.attr('min'))
       this.addConstraint('min', this.$element.attr('min'), undefined, true);
 
     // HTML5 max
-    else if ('undefined' !== typeof this.$element.attr('max'))
+    else if (this.$element.attr('type') !== 'date' && 'undefined' !== typeof this.$element.attr('max'))
       this.addConstraint('max', this.$element.attr('max'), undefined, true);
 
 


### PR DESCRIPTION
Problem
--------
_Since the 'range', 'min' and 'max' attributes have a different meaning when using them in a date html field, parsley will fail on processing these._

This is because Parsley expects a integer, where a date field expects a string.

Solution
--------
The min/max/range attributes have no validation purposes when used on a date field.They are only used for user experience (modifying the calender popup).

My solution exists of ignoring the min/max/range validator, when attributes are present on a date field.
