### PR TITLE
Make jQuery a devDependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,9 +33,6 @@
     "url": "https://github.com/guillaumepotier/Parsley.js/issues"
   },
   "homepage": "https://github.com/guillaumepotier/Parsley.js",
-  "dependencies": {
-    "jquery": ">=1.8.0"
-  },
   "devDependencies": {
     "babel-core": "^5.2.17",
     "babel-eslint": "^4.0.5",
@@ -66,6 +63,7 @@
     "gulp-git": "^1.7.0",
     "inputevent": "*",
     "isparta": "~3.0.3",
+    "jquery": ">=1.8.0",
     "mocha": "^2.1.0",
     "moment": "*",
     "run-sequence": "^1.0.2",


### PR DESCRIPTION
When Parsley is executed in a node environment (such as with bundlers like Browserify or test runners like Mocha), Parsley will not be properly attached to the primary instance of jQuery used in the project. 

The reason is that Parsley includes jQuery 1.11.x as a dependency, so it's internal reference to `require('jquery')` references that version. If the global version of jQuery used by the project is the same version, then there is not problem. But if a different version is used, then Parsley attaches itself to a jQuery object that is not used anywhere else in the project.

Adding jQuery to this project should only be required to run tests in a dev environment. I don't see any need to have jQuery as a production dependency. If I'm wrong then let me know and we can find another solution.

The issue this PR fixes is reported here: #1104
