### PR TITLE
Add section to help with remote validation with groups

### DIFF
--- a/doc/index.html
+++ b/doc/index.html
@@ -1202,8 +1202,18 @@ window.Parsley.addAsyncValidator('mycustom', function (xhr) {
   }, 'http://mycustomapiurl.ext');
 &lt;/script>
 </code></pre>
-            </li>
-          </ul>
+        </p>
+
+        <h3 id="remote-validation">Combining Remote Validations with Groups</h3>
+        <p>If you need to trigger validate outside of form submission, such as with <code>data-parsley-group="group-name"</code>, you'll need to make use of the promises provided in <code>whenValidate({group, force})</code>. The <code>validate({group, force})</code> method that returns a <code>boolean</code> or <code>null</code> will always return <code>null</code> due to remote validation always returning open promises.
+<pre><code>&lt;script type="text/javascript">
+$("form").parsley().whenValidate({
+  group: 2
+}).done(function() {
+  // trigger step change
+});
+&lt;/script>
+</code></pre>
         </p>
 
         <!-- ****************** Extra ****************** -->


### PR DESCRIPTION
After spending a few hours trying to figure out why I could not move forward on my paged/stepped form despite the form step appearing to be completely valid, I discovered it was because I added a new `data-parsley-remote` validation that was returning a promise instead of a boolean. This was causing `validate({group: "group"})` to return `null` due to a "pending validation" per your documentation, despite a `.parsley-success` in the markup.

Since the result was pretty straightforward, I thought I'd add a snippet to the `Parsley Remote` documentation section to mention to use `whenValidate()` instead of `validate()` when working with remote validations. 

Here is what it looks like once rendered (top section is what exists, bottom is new):
<img width="867" alt="screen shot 2017-02-03 at 12 57 57 pm" src="https://cloud.githubusercontent.com/assets/2660801/22602404/11439c08-ea11-11e6-8c76-926904ae3e67.png">

Happy to update the text however you see fit, but I can see this being super useful to have directly in the documentation instead of all over stack overflow!