### PR TITLE
Don't warn on a normal but empty jQuery set

### DIFF
--- a/src/parsley/main.js
+++ b/src/parsley/main.js
@@ -47,8 +47,6 @@ $.fn.parsley = $.fn.psly = function (options) {
 
   // Return undefined if applied to non existing DOM element
   if (!$(this).length) {
-    ParsleyUtils.warn('You must bind Parsley on an existing element.');
-
     return;
   }
 

--- a/test/unit/parsley.js
+++ b/test/unit/parsley.js
@@ -98,9 +98,7 @@ describe('ParsleyFactory', () => {
     expect(parsleyInstance.options.foo).to.be('bar');
   });
   it('should have a jquery API returning undefined if done on a non existing element', () => {
-    expectWarning(() => {
-      expect($('#foo').parsley()).to.be(undefined);
-    });
+    expect($('#foo').parsley()).to.be(undefined);
   });
   it('should have a jquery API that binds multiple selectors', () => {
     $('body').append('<div id="element">' +


### PR DESCRIPTION
It is the norm for jQuery plugins to be invoked with a selector which may not have any matches on the current document.  In the case of Parsley for example, we get this warning on all pages that don't include any form inputs, which is unnecessary.

(This is in reference to #562 which addressed the DOM half.)