### PR TITLE
Fixes error if classHandler is a string but $(classHandler) has length = 0

### DIFF
--- a/src/parsley/ui.js
+++ b/src/parsley/ui.js
@@ -257,11 +257,17 @@ ParsleyUI.Field = {
   // Determine which element will have `parsley-error` and `parsley-success` classes
   _manageClassHandler: function () {
     // An element selector could be passed through DOM with `data-parsley-class-handler=#foo`
-    if ('string' === typeof this.options.classHandler && $(this.options.classHandler).length)
+    if ('string' === typeof this.options.classHandler) {
+      if ($(this.options.classHandler).length === 0)
+        ParsleyUtils.warn('No elements found that match the selector `' + this.options.classHandler + '` set in options.classHandler or data-parsley-class-handler');
+
+      //return element or empty set
       return $(this.options.classHandler);
+    }
 
     // Class handled could also be determined by function given in Parsley options
-    var $handler = this.options.classHandler.call(this, this);
+    if ('function' === typeof this.options.classHandler)
+      var $handler = this.options.classHandler.call(this, this);
 
     // If this function returned a valid existing DOM element, go for it
     if ('undefined' !== typeof $handler && $handler.length)


### PR DESCRIPTION
It may happen that the classHandler is a string but the jQuery selector has length 0 because no elements are found.
That means we do not return and later try to use "call" on the string which results in a type error:
`Uncaught TypeError: classHandler.call is not a function`

I added a type check to fix that issue.