### PR TITLE
Remove jquery dependency from constraint.js

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,3 +1,4 @@
 {
-  "blacklist": ["useStrict"]
+  "blacklist": ["useStrict"],
+  "plugins": ["object-assign"]
 }

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
   "devDependencies": {
     "babel-core": "^5.2.17",
     "babel-eslint": "^4.0.5",
+    "babel-plugin-object-assign": "^1.2.1",
     "babelify": "^6.0.0",
     "browserify": "^11.0.1",
     "expect.js": "*",

--- a/src/parsley/constraint.js
+++ b/src/parsley/constraint.js
@@ -1,23 +1,24 @@
-import $ from 'jquery';
 import Utils from './utils';
 import Validator from './validator';
 
-var Constraint = function (parsleyField, name, requirements, priority, isDomConstraint) {
-  var validatorSpec = window.Parsley._validatorRegistry.validators[name];
-  var validator = new Validator(validatorSpec);
+const Constraint = function(parsleyField, name, requirements, priority, isDomConstraint) {
+  const validatorSpec = window.Parsley._validatorRegistry.validators[name];
+  const validator = new Validator(validatorSpec);
+  priority = priority || parsleyField.options[name + 'Priority'] || validator.priority;
+  isDomConstraint = (true === isDomConstraint);
 
-  $.extend(this, {
-    validator: validator,
-    name: name,
-    requirements: requirements,
-    priority: priority || parsleyField.options[name + 'Priority'] || validator.priority,
-    isDomConstraint: true === isDomConstraint
+  Object.assign(this, {
+    validator,
+    name,
+    requirements,
+    priority,
+    isDomConstraint
   });
   this._parseRequirements(parsleyField.options);
 };
 
-var capitalize = function(str) {
-  var cap = str[0].toUpperCase();
+const capitalize = function(str) {
+  const cap = str[0].toUpperCase();
   return cap + str.slice(1);
 };
 
@@ -34,4 +35,3 @@ Constraint.prototype = {
 };
 
 export default Constraint;
-


### PR DESCRIPTION
## Description
The file `constants.js` has dependency on jquery only for using method `$.extend`, I change it to use vanilla method `Object.assign` instead.
I also took the time to apply `const` instead of `var`.

[Object.assign - MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/assign)