### PR TITLE
Fix HTML errors in docs

### DIFF
--- a/doc/about.html
+++ b/doc/about.html
@@ -63,7 +63,7 @@
       <!-- Jumbotron -->
       <div class="jumbotron">
         <h1>About Parsley</h1>
-          <hr></hr>
+          <hr>
 
           <div class="col-md-12">Parsley is an open source, MIT licensed project created by <a href="https://github.com/guillaumepotier" target="_blank">Guillaume Potier</a> and co-maintened by <a href="https://github.com/marcandre" target="_blank">Marc-André</a> now.</div>
 
@@ -80,8 +80,8 @@
       </div>
     </div>
 
-    <script type="text/javascript" src="../bower_components/jquery/dist/jquery.min.js"></script>
-    <script type="text/javascript">
+    <script src="../bower_components/jquery/dist/jquery.min.js"></script>
+    <script>
       $(document).ready(function () {
         $('.download').on('click', function (event) {
           _gaq.push(['_trackEvent','download', 'download ' + $(this).data('version'), $(this).data('version')]);

--- a/doc/download.html
+++ b/doc/download.html
@@ -64,8 +64,7 @@
       <!-- Jumbotron -->
       <div class="jumbotron">
         <h1>Download <em>Parsley</em> <small class="parsley-version">v2.7.0</small></h1>
-          <hr></hr>
-
+          <hr>
           <div class="col-md-12"><h2>Whole project..</h2></div>
 
           <div class="col-md-12"><code>$ bower install --save parsleyjs</code></div>
@@ -88,8 +87,8 @@
       </div>
     </div>
 
-    <script type="text/javascript" src="../bower_components/jquery/dist/jquery.min.js"></script>
-    <script type="text/javascript">
+    <script src="../bower_components/jquery/dist/jquery.min.js"></script>
+    <script>
       $(document).ready(function () {
         $('.download').on('click', function (event) {
           _gaq.push(['_trackEvent','download', 'download ' + $(this).data('version'), $(this).data('version')]);
@@ -97,7 +96,7 @@
         });
       });
     </script>
-    <script type="text/javascript">
+    <script>
       var _gaq = _gaq || [];
       _gaq.push(['_setAccount', 'UA-37229467-1']);
       _gaq.push(['_trackPageview']);

--- a/doc/examples.html
+++ b/doc/examples.html
@@ -120,7 +120,7 @@
         <a href="examples/custom-validator-events.html">
           <div class="col-lg-4">
             <h2>Validating a group on inputs</h2>
-            <p class="argument">Validations dependent on more than one inputs can be difficult to achieve (and we are working on this). See how you could leverage Parsley's ability to <strong>validate <tt>&lt;div></tt> and other non inputs</strong> to validate groups of inputs!</p>
+            <p class="argument">Validations dependent on more than one inputs can be difficult to achieve (and we are working on this). See how you could leverage Parsley's ability to <strong>validate <code>&lt;div&gt;</code> and other non inputs</strong> to validate groups of inputs!</p>
             <p class="link">View example &raquo;</p>
           </div>
         </a>
@@ -141,12 +141,12 @@
       </div>
     </div>
 
-    <script type="text/javascript" src="../bower_components/jquery/dist/jquery.min.js"></script>
-    <script type="text/javascript" src="../bower_components/bootstrap/js/affix.js"></script>
-    <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/7.3/highlight.min.js"></script>
+    <script src="../bower_components/jquery/dist/jquery.min.js"></script>
+    <script src="../bower_components/bootstrap/js/affix.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/7.3/highlight.min.js"></script>
 
-    <script type="text/javascript" src="../dist/parsley.js"></script>
-    <script type="text/javascript">
+    <script src="../dist/parsley.js"></script>
+    <script>
       var _gaq = _gaq || [];
       _gaq.push(['_setAccount', 'UA-37229467-1']);
       _gaq.push(['_trackPageview']);

--- a/doc/help.html
+++ b/doc/help.html
@@ -10,9 +10,6 @@
 
     <title>Parsley - Find the help you need</title>
 
-    <!-- Mochat tests css -->
-    <link rel="stylesheet" href="../node_modules/mocha/mocha.css" />
-
     <!-- Bootstrap core CSS -->
     <link href="../bower_components/bootstrap/dist/css/bootstrap.min.css" rel="stylesheet">
 
@@ -63,43 +60,43 @@
           <li><a href="about.html">About</a></li>
         </ul>
 
-
-      <!-- Jumbotron -->
-      <div class="jumbotron">
-        <h1>Help: bugs & community</h1>
-        <small>You're not alone..</small>
-        <hr></hr>
-      </div>
-      <div class="col-md-6">
-        <div class="bs-callout bs-callout-info">
-          <h4>StackOverflow: need a hand, not sure how to do something?</h4>
-          <p>
-            Parsley ships with a lot of easy to use built-in stuff, be <a href="index.html">sure to read the doc!</a>. In some cases, you'll need to work more deeply with listeners, internals.. If you're stuck, have a look at <a href="http://stackoverflow.com/questions/tagged/parsley.js">StackOverflow's great Parsley questions and answers</a>.
-          </p>
+        <!-- Jumbotron -->
+        <div class="jumbotron">
+          <h1>Help: bugs & community</h1>
+          <small>You're not alone..</small>
+          <hr></hr>
         </div>
-        <div id="stack" class="uwidget" data-height="400px" data-width="100%"></div>
-      </div>
-      <div class="col-md-6">
-        <div class="bs-callout bs-callout-warning">
-          <h4>GitHub: found a bug or want to contribute?</h4>
-          <p>
-            If you are either pretty sure that you spotted a vicious bug, or have a great feature implementation / idea, be sure to go to <a href="https://github.com/guillaumepotier/Parsley.js">GitHub</a> and open an issue or a pull request.
-          </p>
+        <div class="col-md-6">
+          <div class="bs-callout bs-callout-info">
+            <h4>StackOverflow: need a hand, not sure how to do something?</h4>
+            <p>
+              Parsley ships with a lot of easy to use built-in stuff, be <a href="index.html">sure to read the doc!</a>. In some cases, you'll need to work more deeply with listeners, internals.. If you're stuck, have a look at <a href="http://stackoverflow.com/questions/tagged/parsley.js">StackOverflow's great Parsley questions and answers</a>.
+            </p>
+          </div>
+          <div id="stack" class="uwidget" data-height="400px" data-width="100%"></div>
         </div>
-        <div id="gh" class="uwidget" data-height="400px" data-width="100%"></div>
-      </div>
-      <div class="clearfix"></div>
+        <div class="col-md-6">
+          <div class="bs-callout bs-callout-warning">
+            <h4>GitHub: found a bug or want to contribute?</h4>
+            <p>
+              If you are either pretty sure that you spotted a vicious bug, or have a great feature implementation / idea, be sure to go to <a href="https://github.com/guillaumepotier/Parsley.js">GitHub</a> and open an issue or a pull request.
+            </p>
+          </div>
+          <div id="gh" class="uwidget" data-height="400px" data-width="100%"></div>
+        </div>
+        <div class="clearfix"></div>
 
         <!-- Site footer -->
         <div class="footer">
           <p>&copy; <a href="https://twitter.com/guillaumepotier" title="Guillaume Potier on Twitter">Guillaume Potier</a> 2014 - <a href="http://wisembly.com">@Wisembly</a></p>
         </div>
       </div>
+    </div>
 
-    <script type="text/javascript" src="../bower_components/jquery/dist/jquery.min.js"></script>
+    <script src="../bower_components/jquery/dist/jquery.min.js"></script>
     <script src="../bower_components/uwidget/uwidget.js"></script>
 
-    <script type="text/javascript">
+    <script>
     $(document).ready(function () {
       $('#gh').UWidget({
         url: 'https://api.github.com/repos/guillaumepotier/Parsley.js/issues',
@@ -147,29 +144,29 @@
         }
       });
     });
-  </script>
-  <script type="text/html" id="gh_tmpl">
-    <li>
-      <span class="gh-issue-comments">
-        <%= comments %> <%= comments > 1 ? "comments" : "commment" %>
-      </span>
-      <span class="gh-issue-title">
-        <a href="<%= html_url %>"><%= title %></a>
-      </span>
-    </li>
-  </script>
-  <script type="text/html" id="stack_tmpl">
-    <li>
-      <span class="stack-question-answers">
-        <%= answer_count %> <%= answer_count > 1 ? "answers" : "answer" %>
-      </span>
-      <span class="stack-question-title">
-        <a href="<%= link %>"><%= title %></a>
-      </span>
-    </li>
-  </script>
+    </script>
+    <script type="text/html" id="gh_tmpl">
+      <li>
+        <span class="gh-issue-comments">
+          <%= comments %> <%= comments > 1 ? "comments" : "commment" %>
+        </span>
+        <span class="gh-issue-title">
+          <a href="<%= html_url %>"><%= title %></a>
+        </span>
+      </li>
+    </script>
+    <script type="text/html" id="stack_tmpl">
+      <li>
+        <span class="stack-question-answers">
+          <%= answer_count %> <%= answer_count > 1 ? "answers" : "answer" %>
+        </span>
+        <span class="stack-question-title">
+          <a href="<%= link %>"><%= title %></a>
+        </span>
+      </li>
+    </script>
 
-    <script type="text/javascript">
+    <script>
       var _gaq = _gaq || [];
       _gaq.push(['_setAccount', 'UA-37229467-1']);
       _gaq.push(['_trackPageview']);
@@ -180,5 +177,5 @@
         var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ga, s);
       })();
     </script>
-    </body>
+  </body>
 </html>

--- a/doc/index.html
+++ b/doc/index.html
@@ -1,3 +1,4 @@
+
 <!DOCTYPE html>
 <html lang="en">
   <head>
@@ -117,12 +118,12 @@
             Finally, add <code>data-parsley-validate</code> to each <code>&lt;form></code> you want to be validated.
           </p>
           <p>That would look pretty much like this:
-<pre><code>&lt;script src="jquery.js">&lt;/script>
-&lt;script src="parsley.min.js">&lt;/script>
+<pre><code>&lt;script src="jquery.js"&gt;&lt;/script&gt;
+&lt;script src="parsley.min.js"&gt;&lt;/script&gt;
 
-&lt;form data-parsley-validate>
+&lt;form data-parsley-validate&gt;
 ...
-&lt;/form>
+&lt;/form&gt;
 </code></pre>
           </p>
 
@@ -135,16 +136,16 @@
           <p>Like for <a href="#installation-basic">Basic installation</a>, first include <strong>jQuery</strong> and Parsley. Then, simply use <code>$('#form').parsley(options);</code> or <code>new Parsley('#form', options);</code> (where <code>options</code> is an optional configuration object) to manually bind Parsley to your forms.</p>
 
           <p>That would look pretty much like this:
-<pre><code>&lt;script src="jquery.js">&lt;/script>
-&lt;script src="parsley.min.js">&lt;/script>
+<pre><code>&lt;script src="jquery.js"&gt;&lt;/script&gt;
+&lt;script src="parsley.min.js"&gt;&lt;/script&gt;
 
-&lt;form id="form">
+&lt;form id="form"&gt;
 ...
-&lt;/form>
+&lt;/form&gt;
 
-&lt;script type="text/javascript">
+&lt;script&gt;
   $('#form').parsley();
-&lt;/script>
+&lt;/script&gt;
 </code></pre>
 
           <div class="bs-callout bs-callout-danger">
@@ -162,14 +163,12 @@
           </p>
           <p>
             To load a different locale and its messages, include them after Parsley:
-<pre><code>&lt;script src="jquery.js">&lt;/script>
-&lt;script src="parsley.min.js">&lt;/script>
-&lt;script src="i18n/fr.js">&lt;/script>
-&lt;script src="i18n/it.js">&lt;/script>
+<pre><code>&lt;script src="jquery.js"&gt;&lt;/script&gt;
+&lt;script src="parsley.min.js"&gt;&lt;/script&gt;
+&lt;script src="i18n/fr.js"&gt;&lt;/script&gt;
+&lt;script src="i18n/it.js"&gt;&lt;/script&gt;
 </code></pre>
                 The last loaded file will automatically set the messages locale for Parsley. In the example above, we load both French and Italian translations, and use Italian.
-            </li>
-            </ul>
           </p>
 
           <h3 id="installation-plugins">Plugins</h3>
@@ -314,7 +313,7 @@ if (false === instance.options.priorityEnabled)
                   <code>textarea,</code><br/>
                   <code>select</code></td>
                 <td>When looking for fields within a form, Parsley uses this selector.
-                  The fields found will then be filtered using the <code>excluded<code> option below.</td>
+                  The fields found will then be filtered using the <code>excluded</code> option below.</td>
               </tr>
               <tr>
                 <td><code>data-parsley-excluded</code> <version>#2.0</version></td>
@@ -475,9 +474,10 @@ if (false === instance.options.priorityEnabled)
                 </td>
                 <td>Validate Field. <strong>Fires <a href="#events">events</a> and affects UI.</strong> If <code>force</code> is set, force validate even non required fields (<a href="examples/events.html">See example</a>)</td>
               </tr>
-              <td>Get errors messages <version>#2.0</version></td>
-                <td><code>getErrorsMessages();</code></td>
-                <td>Returns an array of the field errors messages displayed once validated.</td>
+              <tr>
+                <td><code>getErrorsMessages()</code> <version>#2.0</version></td>
+                <td><code>array</code></td>
+                <td>Returns an array of field's error messages</td>
               </tr>
               <tr>
                 <td><code>reset()</code> <version>#2.0</version></td>
@@ -785,15 +785,16 @@ if (false === instance.options.priorityEnabled)
             These validators are shipped in <code>parsley.js</code>. Have a look at <a href="#extras">Parsley Extras</a> for more validators.
           </p>
 
-          <h1 id="custom">Custom Validators</h3>
+          <!-- ****************** CUSTOM VALIDATORS ****************** -->
+          <h1 id="custom" class="page-header">Custom Validators</h1>
           <h3 id="custom-intro">Craft yours</h3>
           <p>Of course, Parsley built-in validators are commonly used validators, and you'll need some more that fit your specific forms and validations. That's why Parsley lets you easily create your own validators.</p>
           <p>
           <p>The preferred way to register them (after <code>parsley.js</code> is loaded) looks like:
 
-<pre><code>&lt;input type="text" data-parsley-multiple-of="3" />
+<pre><code>&lt;input type="text" data-parsley-multiple-of="3" /&gt;
 [...]
-&lt;script type="text/javascript">
+&lt;script&gt;
 window.Parsley
   .addValidator('multipleOf', {
     requirementType: 'integer',
@@ -805,7 +806,7 @@ window.Parsley
       fr: 'Cette valeur doit être un multiple de %s'
     }
   });
-&lt;/script>
+&lt;/script&gt;
 </code></pre>
           </p>
           <p>The following sections go over the details on how to define a custom validator</p>
@@ -932,7 +933,7 @@ window.Parsley
             <tr>
               <td>Focus <version>#2.0</version></td>
               <td><code>data-parsley-focus="first"</code></td>
-              <td>Focus failing field on form validation. Possible values: <code>'first' | 'last' | 'none'<code></td>
+              <td>Focus failing field on form validation. Possible values: <code>'first' | 'last' | 'none'</code></td>
             </tr>
           </tbody>
         </table>
@@ -953,11 +954,12 @@ window.Parsley
               <td>Specify one or many javascript events that will trigger item validation, before any failure. To set multiple events, separate them with a space <code>data-parsley-trigger="focusin focusout"</code>. Default is <code>null</code>. <a href="http://api.jquery.com/category/events/" target="_blank">See the various events supported by jQuery.</a></td>
             </tr>
             <tr>
-              <td>Trigger After Failure<version>#2.0</version></td>
+              <td>Trigger After Failure <version>#2.0</version></td>
               <td><code>data-parsley-trigger-after-failure="focusout"</code></td>
               <td>Specify one or many javascript events that will trigger item validation, after the first failure. Default is <a href="https://developer.mozilla.org/en-US/docs/Web/Events/input"><code>'input'</code></a>.</td>
             </tr>
-            <td>No focus <version>#2.0</version></td>
+            <tr>
+              <td>No focus <version>#2.0</version></td>
               <td><code>data-parsley-no-focus</code></td>
               <td>If this field fails, do not focus on it (if <code>first</code> focus strategy is on, next field would be focused, if <code>last</code> strategy is on, previous field would be focused)</td>
             </tr>
@@ -1008,16 +1010,19 @@ window.Parsley
               <td><code>addError(name, {message: , assert: , updateClass: true});</code></td>
               <td>Add an error message.</td>
             </tr>
-            <td>Update error <version>#2.0</version></td>
+            <tr>
+              <td>Update error <version>#2.0</version></td>
               <td><code>updateError(name, {message: , assert: , updateClass: true});</code></td>
               <td>Update an already added error message error.</td>
             </tr>
-            <td>Remove error <version>#2.0</version></td>
+            <tr>
+              <td>Remove error <version>#2.0</version></td>
               <td><code>removeError(name, {updateClass: true});</code></td>
               <td>Remove an already present error.</td>
             </tr>
           </tbody>
         </table>
+
         <!-- ****************** Events ****************** -->
         <h1 id="events" class="page-header">Events</h1>
         <h3 id="events-overview">Overview</h3>
@@ -1122,7 +1127,7 @@ window.Parsley
           Parsley <a href="annotated-source/remote.html" target="_blank">remote</a> is an easy to use <strong>ajax asynchronous validator</strong>.
         </p>
 
-        <h3>Options</h3>
+        <h3 id="remote-options">Options</h3>
         <table class="table table-stripped table-bordered">
           <thead>
             <tr>
@@ -1196,30 +1201,27 @@ window.Parsley
           </tbody>
         </table>
 
-        <a name="remote-custom"></a>
-        <h3>Custom remote validators</h3>
+        <h3 id="remote-custom">Custom remote validators</h3>
         <p>If you need some custom processing of Ajax responses, configure your custom remote as follows:
-<pre><code>&lt;input name="q" type="text" data-parsley-remote data-parsley-remote-validator='mycustom' value="foo" />
+<pre><code>&lt;input name="q" type="text" data-parsley-remote data-parsley-remote-validator='mycustom' value="foo" /&gt;
 [...]
-&lt;script href="parsley.remote.js">&lt;/script>
-&lt;script type="text/javascript">
+&lt;script href="parsley.remote.js"&gt;&lt;/script&gt;
+&lt;script&gt;
 window.Parsley.addAsyncValidator('mycustom', function (xhr) {
     console.log(this.$element); // jQuery Object[ input[name="q"] ]
 
     return 404 === xhr.status;
   }, 'http://mycustomapiurl.ext');
-&lt;/script>
+&lt;/script&gt;
 </code></pre>
-            </li>
-          </ul>
         </p>
 
-        <!-- ****************** Extra ****************** -->
+        <!-- ****************** Extras ****************** -->
         <h1 id="extras" class="page-header">Parsley Extras</h1>
         <p>
           You'll find in the <code>src/extra/</code> directory in Parsley .zip or Github projects many more or less useful validators crafted by the community. A doc here is coming.
         </p>
-        <h3 id="validators-list">Validators list</h3>
+        <h3 id="extras-validators-list">Validators list</h3>
         <table class="table table-stripped table-bordered">
           <thead>
            <tr>
@@ -1418,9 +1420,18 @@ window.Parsley.addAsyncValidator('mycustom', function (xhr) {
               </li>
               <li>
                 <a href="#remote">Parsley Remote</a>
+                <ul class="nav">
+                  <li><a href="#remote-options">Options</a></li>
+                  <li><a href="#remote-events">Events</a></li>
+                  <li><a href="#remote-methods">Methods</a></li>
+                  <li><a href="#remote-custom">Custom remote validators</a></li>
+                </ul>
               </li>
               <li>
                 <a href="#extras">Parsley Extras</a>
+                <ul class="nav">
+                  <li><a href="#extras-validators-list">Validators list</a></li>
+                </ul>
               </li>
           </ul>
           <a class="back-to-top" href="#top">
@@ -1429,8 +1440,8 @@ window.Parsley.addAsyncValidator('mycustom', function (xhr) {
 
           <div id="mailing-list">
             <!-- Begin MailChimp Signup Form -->
-            <link href="//cdn-images.mailchimp.com/embedcode/slim-081711.css" rel="stylesheet" type="text/css">
-            <style type="text/css">
+            <link href="//cdn-images.mailchimp.com/embedcode/slim-081711.css" rel="stylesheet">
+            <style>
               #mc_embed_signup{background:#fff; clear:left; font:14px Helvetica,Arial,sans-serif; }
               /* Add your own MailChimp form style overrides in your site stylesheet or in this style block.
                  We recommend moving this block and the preceding CSS link to the HEAD of your HTML file. */
@@ -1458,15 +1469,14 @@ window.Parsley.addAsyncValidator('mycustom', function (xhr) {
       </div>
     </div>
 
-    <script type="text/javascript" src="../bower_components/jquery/dist/jquery.min.js"></script>
-    <script type="text/javascript" src="../bower_components/bootstrap/js/affix.js"></script>
-    <script type="text/javascript" src="../bower_components/bootstrap/js/scrollspy.js"></script>
-    <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/7.3/highlight.min.js"></script>
-    <script type="text/javascript" src="assets/docs.js"></script>
-    <script type="text/javascript" src="../dist/parsley.min.js"></script>
+    <script src="../bower_components/jquery/dist/jquery.min.js"></script>
+    <script src="../bower_components/bootstrap/js/affix.js"></script>
+    <script src="../bower_components/bootstrap/js/scrollspy.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/7.3/highlight.min.js"></script>
+    <script src="assets/docs.js"></script>
+    <script src="../dist/parsley.min.js"></script>
 
-    <script type="text/javascript">
-
+    <script>
       try {
         hljs.initHighlightingOnLoad();
       } catch ( err ) {}

--- a/doc/tests.html
+++ b/doc/tests.html
@@ -11,7 +11,7 @@
     <title>Parsley - Test suite</title>
 
     <!-- Mochat tests css -->
-    <link rel="stylesheet" href="../bower_components/mocha/mocha.css" />
+    <link rel="stylesheet" href="../bower_components/mocha/mocha.css">
 
     <!-- Bootstrap core CSS -->
     <link href="../bower_components/bootstrap/dist/css/bootstrap.min.css" rel="stylesheet">
@@ -37,7 +37,6 @@
 
   <body>
     <div class="container">
-
       <div class="masthead">
         <div class="header">
           <h3 class="text-muted"><a href="../">Parsley</a></h3>
@@ -73,8 +72,9 @@
           <p>&copy; <a href="https://twitter.com/guillaumepotier" title="Guillaume Potier on Twitter">Guillaume Potier</a> 2014 - <a href="http://wisembly.com">@Wisembly</a></p>
         </div>
       </div>
+    </div>
 
-    <script type="text/javascript">
+    <script>
       var _gaq = _gaq || [];
       _gaq.push(['_setAccount', 'UA-37229467-1']);
       _gaq.push(['_trackPageview']);
@@ -85,5 +85,5 @@
         var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ga, s);
       })();
     </script>
-    </body>
+  </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -173,7 +173,7 @@
 
     </div> <!-- /container -->
 
-    <script type="text/javascript">
+    <script>
       var _gaq = _gaq || [];
       _gaq.push(['_setAccount', 'UA-37229467-1']);
       _gaq.push(['_trackPageview']);


### PR DESCRIPTION
- `il, ul` on index.html - after 50d2f7b44bf0dae16b0560cfd8c91b56f4de9d1b
- `>` -> `&gt;` in `<code><pre>...</pre></code>`
- `<tt>` is deleted on HTML5
- Update navigation for extras and remote
- Remove duplicated id (`validators-list`)
- Fix not closed `<code>` and not opened `<tr>` tags
- Add `class="page-header"` for `h1#custom`
- Fix `getErrorsMessages` order cell.
...

Check by https://validator.w3.org/