### PR TITLE
An option to skip validation of a field if it has a certain attribute and a certain field's value

### DIFF
--- a/src/parsley/defaults.js
+++ b/src/parsley/defaults.js
@@ -15,6 +15,9 @@ var Defaults = {
   // Excluded inputs by default
   excluded: 'input[type=button], input[type=submit], input[type=reset], input[type=hidden]',
 
+  // The field is excluded from validation, if it has at least one of the specified combinations of an attribute and field's value
+  excludeIfAttributeAndValue: {},
+
   // Stop validating field on highest priority failing constraint
   priorityEnabled: true,
 

--- a/src/parsley/field.js
+++ b/src/parsley/field.js
@@ -76,13 +76,26 @@ Field.prototype = {
 
   // An empty optional field does not need validation
   needsValidation: function (value) {
+    var skipValidation = false;
+
     if ('undefined' === typeof value)
       value = this.getValue();
 
+    // Determine if the field is to be excluded from validation based on its attribute and value
+    if ('undefined' !== typeof this.options.excludeIfAttributeAndValue) {
+      var thisElement = this.$element;
+      $.each( this.options.excludeIfAttributeAndValue, function( key, val ) {
+        var attr = thisElement.attr(key);
+        if (typeof undefined !== typeof attr && false !== attr && val === value)
+          skipValidation = true;
+      });
+    }
+
     // If a field is empty and not required, it is valid
     // Except if `data-parsley-validate-if-empty` explicitely added, useful for some custom validators
-    if (!value.length && !this._isRequired() && 'undefined' === typeof this.options.validateIfEmpty)
+    if ( (!value.length && !this._isRequired() && 'undefined' === typeof this.options.validateIfEmpty) || skipValidation ) {
       return false;
+    }
 
     return true;
   },

--- a/test/unit/form.js
+++ b/test/unit/form.js
@@ -183,6 +183,19 @@ describe('Form', () => {
       expect($('#element').parsley().validate(undefined, true)).to.be(false);
     });
   });
+  it('should have an excludeIfAttributeAndValue option', () => {
+    $('body').append('<form id="element" data-parsley-required>' +
+      '<input type="text" id="field1" value="baz" data-parsley-minlength="5"/></form>');
+    var form = $('#element');
+    expect(form.parsley().isValid()).to.be(false);
+    $('#element').attr('data-parsley-exclude-if-attribute-and-value', '{"foo":"bar"}');
+    $('#field1').attr('foo','');
+    expect(form.parsley().isValid()).to.be(false);
+    form.parsley().destroy();
+    form.parsley();
+    $('#field1').val('bar');
+    expect(form.parsley().isValid()).to.be(true);
+  });
   it('should properly bind dynamically added fields', () => {
     $('body').append('<form id="element" data-parsley-trigger="change"></form>');
     $('#element').append('<input type="email" id="email" required />');


### PR DESCRIPTION
This is useful in case if you accept certain field values that would fail a normal validation.

Example: your form has "Organization" field where users put their affiliation. However, some users might have no such information. To make sure that they actually read through the form, you require them to put 'N/A' into the field. If the field's minimum length is 10, then just 'N/A' would fail validation. With this option, it would not.