### PR TITLE
Remove duplicate license

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,6 @@
     "email": "guillaume@wisembly.com",
     "url": "http://guillaumepotier.com/"
   },
-  "license": "MIT",
   "bugs": {
     "url": "https://github.com/guillaumepotier/Parsley.js/issues"
   },


### PR DESCRIPTION
The homepage key is also duplicate, not sure if that's intentional, but I doubt the license was