### PR TITLE
solves #1226 - replacing pipe with then

### DIFF
--- a/src/parsley/field.js
+++ b/src/parsley/field.js
@@ -67,7 +67,7 @@ Field.prototype = {
       .done(() =>   { this._trigger('success'); })
       .fail(() =>   { this._trigger('error'); })
       .always(() => { this._trigger('validated'); })
-      .pipe(...this._pipeAccordingToValidationResult());
+      .then(...this._pipeAccordingToValidationResult());
   },
 
   hasConstraints: function () {

--- a/src/parsley/form.js
+++ b/src/parsley/form.js
@@ -111,7 +111,7 @@ Form.prototype = {
         this._trigger('error');
       })
       .always(() => { this._trigger('validated'); })
-      .pipe(...this._pipeAccordingToValidationResult());
+      .then(...this._pipeAccordingToValidationResult());
   },
 
   // Iterate over refreshed fields, and stop on first failure.


### PR DESCRIPTION
This solves #1226 by replacing deferred.pipe with deferred.then.
deferred.pipe is deprecated sind jQuery 1.8 (documentation http://api.jquery.com/deferred.pipe/)