### PR TITLE
Normal triggers no more binded after first failure

### DIFF
--- a/src/parsley/ui.js
+++ b/src/parsley/ui.js
@@ -330,7 +330,7 @@ UI.Field = {
       $toBind.on(Utils.namespaceEvents(this.options.triggerAfterFailure, 'Parsley'), () => {
         this._validateIfNeeded();
       });
-    else if (trigger = Utils.namespaceEvents(this.options.trigger, 'Parsley')) {
+    if (trigger = Utils.namespaceEvents(this.options.trigger, 'Parsley')) {
       $toBind.on(trigger, event => {
         this._validateIfNeeded(event);
       });


### PR DESCRIPTION
There was an else after `if (this._failedOnce)`. This way the binds on normal triggers were not rebinded if the field has failed once.