### PR TITLE
Create datecomparison.js

### DIFF
--- a/src/extra/validator/datecomparison.js
+++ b/src/extra/validator/datecomparison.js
@@ -1,0 +1,54 @@
+// Load this after Parsley for additional date comparison validators
+// Note: comparing with a reference isn't well supported and not recommended.
+// import jQuery from 'jquery'; // Remove this line in ES3
+
+// date-gt, date-lt extra validators
+
+// data-parsley-date-gt
+window.Parsley
+    .addValidator('dateGt', {
+        requirementType: 'string',
+        validateString: function(value, requirement) {
+
+            // get the values of targeted input as an array
+            let comparedToDate = $(requirement).val().split('-');
+            // get the values of initial input as an array
+            let comparedDate = value.split('-');
+
+            let i;
+            for (i = 0; i < comparedToDate.length; i++) {
+                if (comparedToDate[i] !== comparedDate[i]) {
+                    return comparedDate[i] > comparedToDate[i];
+                }
+            }
+
+        },
+        messages: {
+            en: 'This date must be far.',
+            fr: 'Cette date doit être plus loin'
+        }
+    });
+
+// data-parsley-date-lt
+window.Parsley
+    .addValidator('dateLt', {
+        requirementType: 'string',
+        validateString: function(value, requirement) {
+
+            // get the values of targeted input as an array
+            let comparedToDate = $(requirement).val().split('-');
+            // get the values of initial input as an array
+            let comparedDate = value.split('-');
+
+            let i;
+            for (i = 0; i < comparedToDate.length; i++) {
+                if (comparedToDate[i] !== comparedDate[i]) {
+                    return comparedDate[i] < comparedToDate[i];
+                }
+            }
+        },
+        messages: {
+            en: 'This date must be near.',
+            fr: 'Cette date doit être plus proche'
+        }
+    });


### PR DESCRIPTION
# Create date comparison validator
I find a problem when I use **parsley.js** to compare between two inputs with type **month** or **date**
```html
<input type="month" id="from" name="from">
```
or
```html
<input type="date" id="from" name="from">
```
the problem is that **parsley.js** compares just between years but it doesn't take into consideration days or months when it compares 
## for example :
I want to make sure that the date in the input **from** must be near than the input **to**
```html
<input type="month" id="from" name="from">
<input type="month" id="to" name="to">
```
so I write these two functions to try to fix this problem