### PR TITLE
Update gulp patterns for v4

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "@babel/polyfill": "^7.0.0",
     "@babel/preset-env": "^7.0.0",
     "@babel/register": "^7.0.0",
-    "del": "^1.1.1",
+    "del": "^5.1.0",
     "docco": "~0.6.3",
     "expect.js": "*",
     "glob": "^5.0.14",


### PR DESCRIPTION
Hey hey @marcandre! I saw this gulpfile when getting you set up for Tidelift and figured I'd jump in to help align it with the current recommended patterns for gulp 4.

There's still a bunch of improvements that could be made, like streamlining the function names to avoid all the `displayName` annotations and cleaning up the docco task, but I think this is a great start.