### PR TITLE
docs: Fix simple typo, querry -> query

### DIFF
--- a/dist/parsley.js
+++ b/dist/parsley.js
@@ -2354,7 +2354,7 @@
       }, remoteOptions); // Generate store key based on ajax options
 
       instance.trigger('field:ajaxoptions', instance, ajaxOptions);
-      csr = $.param(ajaxOptions); // Initialise querry cache
+      csr = $.param(ajaxOptions); // Initialise query cache
 
       if ('undefined' === typeof Parsley._remoteCache) Parsley._remoteCache = {}; // Try to retrieve stored xhr
 

--- a/doc/assets/spec-build.js
+++ b/doc/assets/spec-build.js
@@ -2411,7 +2411,7 @@
       }, remoteOptions); // Generate store key based on ajax options
 
       instance.trigger('field:ajaxoptions', instance, ajaxOptions);
-      csr = $.param(ajaxOptions); // Initialise querry cache
+      csr = $.param(ajaxOptions); // Initialise query cache
 
       if ('undefined' === typeof Parsley._remoteCache) Parsley._remoteCache = {}; // Try to retrieve stored xhr
 

--- a/src/parsley/remote.js
+++ b/src/parsley/remote.js
@@ -78,7 +78,7 @@ Parsley.addValidator('remote', {
 
     csr = $.param(ajaxOptions);
 
-    // Initialise querry cache
+    // Initialise query cache
     if ('undefined' === typeof Parsley._remoteCache)
       Parsley._remoteCache = {};
 


### PR DESCRIPTION
There is a small typo in dist/parsley.js, doc/assets/spec-build.js, src/parsley/remote.js.

Should read `query` rather than `querry`.

